### PR TITLE
Adjust Test layout to use CSS module

### DIFF
--- a/src/test/Test.module.css
+++ b/src/test/Test.module.css
@@ -1,0 +1,19 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: 24px;
+  overflow: auto;
+}

--- a/src/test/Test.tsx
+++ b/src/test/Test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Header } from '@shared/ui/header/Header.tsx';
 import { Footer } from '@shared/ui/footer/Footer.tsx';
 import { CardContainer } from '@shared/ui/cardContainer/CardContainer.tsx';
+import styles from './Test.module.css';
 
 interface TestProps {
   appearance: 'light' | 'dark';
@@ -11,13 +12,15 @@ interface TestProps {
 
 export const Test = ({ appearance, setAppearance }: TestProps) => {
   return (
-    <>
+    <div className={styles.page}>
       <Header />
-      <div style={{ display: 'flex', alignItems: 'center' }}>
+      <main className={styles.main}>
         <SideBar appearance={appearance} setAppearance={setAppearance} />
-        <CardContainer />
-      </div>
+        <section className={styles.content}>
+          <CardContainer />
+        </section>
+      </main>
       <Footer />
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a CSS module for the Test page layout structure
- restructure the Test component markup to use the shared layout classes for page, main area, and content section

## Testing
- yarn lint *(fails: existing unused eslint-disable warnings in Yarn-generated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca531a63ac8331b40ca367f7b8ad18