### PR TITLE
Adjust sidebar height handling

### DIFF
--- a/src/shared/ui/sidebar/sidebar.module.css
+++ b/src/shared/ui/sidebar/sidebar.module.css
@@ -1,6 +1,7 @@
 .container {
   width: 268px;
-  min-height: 100vh;
+  height: 100%;
+  min-height: 0;
   padding: 32px 24px 28px;
   box-sizing: border-box;
   background: linear-gradient(180deg, #0a0f1c 0%, #070910 100%);

--- a/src/test/Test.module.css
+++ b/src/test/Test.module.css
@@ -1,0 +1,4 @@
+.main {
+  display: flex;
+  align-items: stretch;
+}

--- a/src/test/Test.tsx
+++ b/src/test/Test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Header } from '@shared/ui/header/Header.tsx';
 import { Footer } from '@shared/ui/footer/Footer.tsx';
 import { CardContainer } from '@shared/ui/cardContainer/CardContainer.tsx';
+import styles from './Test.module.css';
 
 interface TestProps {
   appearance: 'light' | 'dark';
@@ -13,7 +14,7 @@ export const Test = ({ appearance, setAppearance }: TestProps) => {
   return (
     <>
       <Header />
-      <div style={{ display: 'flex', alignItems: 'center' }}>
+      <div className={styles.main}>
         <SideBar appearance={appearance} setAppearance={setAppearance} />
         <CardContainer />
       </div>


### PR DESCRIPTION
## Summary
- update the sidebar container to use a flexible 100% height with a zero minimum
- add a CSS module for the Test page that stretches flex children
- wire the Test component to the CSS module instead of inline styles

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68ca532a82f08331a4dc8ab1d0be3a7c