### PR TITLE
feat: implement light mode styling

### DIFF
--- a/src/app/Main.tsx
+++ b/src/app/Main.tsx
@@ -1,9 +1,15 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Router } from '@app/routes/Router.tsx';
 import { Theme } from '@radix-ui/themes';
 
 export const Main = () => {
-  const [appearance, setAppearance] = useState<'light' | 'dark'>('dark');
+  const [appearance, setAppearance] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(appearance);
+  }, [appearance]);
 
   return (
     <Theme accentColor="iris" appearance={appearance}>

--- a/src/shared/ui/footer/footer.css.ts
+++ b/src/shared/ui/footer/footer.css.ts
@@ -1,5 +1,5 @@
 // src/shared/ui/footer/footer.css.ts
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 import { vars } from '@shared/styles/token.css.ts';
 
 export const box = style({
@@ -75,4 +75,30 @@ export const menuItem = style({
   ':hover': {
     color: '#ffffff', // ✅ hover 시 화이트로 강조
   },
+});
+
+// Light mode overrides
+globalStyle(`.light .${box}`, {
+  background: 'linear-gradient(180deg, #ffffff 0%, #eef2ff 100%)',
+  borderTop: '1px solid rgba(184, 196, 233, 0.8)',
+});
+
+globalStyle(`.light .${container}`, {
+  color: '#2f3762',
+});
+
+globalStyle(`.light .${copy}`, {
+  color: '#5a6594',
+});
+
+globalStyle(`.light .${menuHeading}`, {
+  color: '#111633',
+});
+
+globalStyle(`.light .${menuItem}`, {
+  color: '#3b4573',
+});
+
+globalStyle(`.light .${menuItem}:hover`, {
+  color: '#111633',
 });

--- a/src/shared/ui/header/header.css.ts
+++ b/src/shared/ui/header/header.css.ts
@@ -1,5 +1,5 @@
 // src/shared/ui/header/header.css.ts
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 
 export const box = style({
   position: 'fixed',
@@ -79,4 +79,33 @@ export const loginButtonStyle = style({
     background:
       'linear-gradient(135deg, rgba(134, 159, 255, 0.36), rgba(92, 121, 255, 0.26))',
   },
+});
+
+// Light mode overrides
+globalStyle(`.light .${container}`, {
+  background: 'linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(236, 240, 255, 0.94))',
+  border: '1px solid rgba(184, 196, 233, 0.8)',
+  boxShadow: '0 12px 28px rgba(159, 176, 231, 0.28)',
+});
+
+globalStyle(`.light .${buttonStyle}`, {
+  color: '#2f3762',
+});
+
+globalStyle(`.light .${buttonStyle}:hover`, {
+  background: 'rgba(150, 166, 237, 0.25)',
+  color: '#111633',
+});
+
+globalStyle(`.light .${loginButtonStyle}`, {
+  background:
+    'linear-gradient(135deg, rgba(155, 17, 18, 0.18), rgba(155, 17, 18, 0.12))',
+  color: '#9B1112',
+  boxShadow: '0 10px 22px rgba(155, 17, 18, 0.18)',
+});
+
+globalStyle(`.light .${loginButtonStyle}:hover`, {
+  background:
+    'linear-gradient(135deg, rgba(155, 17, 18, 0.24), rgba(155, 17, 18, 0.16))',
+  color: '#5c0909',
 });

--- a/src/shared/ui/sidebar/sidebar.css.ts
+++ b/src/shared/ui/sidebar/sidebar.css.ts
@@ -1,5 +1,5 @@
 // src/shared/ui/sidebar/sidebar.css.ts
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 
 // 컨테이너
 export const container = style({
@@ -159,4 +159,64 @@ export const controlButton = style({
       outlineOffset: '2px',
     },
   },
+});
+
+// Light mode overrides
+globalStyle(`.light .${container}`, {
+  background: 'linear-gradient(180deg, #f7f9ff 0%, #e8edff 100%)',
+  borderRight: '1px solid rgba(169, 181, 224, 0.7)',
+  color: '#2d3561',
+});
+
+globalStyle(`.light .${menuButton}`, {
+  color: '#3c4574',
+});
+
+globalStyle(`.light .${menuButton}:hover`, {
+  background: 'rgba(137, 156, 232, 0.22)',
+  color: '#141836',
+});
+
+globalStyle(`.light .${menuButtonHighlight}`, {
+  background:
+    'linear-gradient(135deg, rgba(143, 161, 245, 0.28), rgba(103, 133, 236, 0.18))',
+  color: '#141836',
+  boxShadow: '0 12px 28px rgba(120, 145, 226, 0.35)',
+});
+
+globalStyle(`.light .${menuButtonHighlight}:hover`, {
+  background:
+    'linear-gradient(135deg, rgba(165, 181, 248, 0.36), rgba(126, 153, 240, 0.24))',
+});
+
+globalStyle(`.light .${menuButtonOpen}`, {
+  background: 'rgba(147, 167, 255, 0.24)',
+  color: '#141836',
+});
+
+globalStyle(`.light .${iconWrapper}`, {
+  background: 'rgba(153, 168, 226, 0.24)',
+  color: '#5360a3',
+});
+
+globalStyle(`.light .${tag}`, {
+  background: 'rgba(172, 185, 249, 0.34)',
+  color: '#1f2652',
+});
+
+globalStyle(`.light .${divider}`, {
+  background:
+    'linear-gradient(90deg, rgba(176, 189, 233, 0) 0%, rgba(176, 189, 233, 0.85) 50%, rgba(176, 189, 233, 0) 100%)',
+});
+
+globalStyle(`.light .${controlButton}`, {
+  background: 'rgba(244, 247, 255, 0.92)',
+  border: '1px solid rgba(176, 189, 233, 0.75)',
+  color: '#2f3762',
+});
+
+globalStyle(`.light .${controlButton}:hover`, {
+  background: 'rgba(231, 237, 255, 0.96)',
+  borderColor: 'rgba(148, 166, 233, 0.95)',
+  color: '#111633',
 });


### PR DESCRIPTION
## Summary
- default the app to the light appearance and keep the html class list in sync with the selected theme
- add light mode specific overrides for the sidebar, header, and footer while preserving the existing dark styling

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db369c5e0083318725adf1e81e0e04