### PR TITLE
Add home layout and hero light mode styles

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -1,8 +1,8 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { Test } from '@src/test/Test.tsx';
 import React from 'react';
 import { BoardPage } from '@src/domain/board/pages/BoardPage.tsx';
 import { CardContainer } from '@src/components/card/cardContainer/CardContainer.tsx';
+import { Home } from '@src/pages/home/Home.tsx';
 
 interface RouterProps {
   appearance: 'light' | 'dark';
@@ -16,7 +16,7 @@ export const Router = ({ appearance, setAppearance }: RouterProps) => {
         <Route
           path="/"
           element={
-            <Test appearance={appearance} setAppearance={setAppearance} />
+            <Home appearance={appearance} setAppearance={setAppearance} />
           }
         />
         <Route

--- a/src/components/hero/hero.css.ts
+++ b/src/components/hero/hero.css.ts
@@ -1,4 +1,5 @@
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
+import { lightVars } from '@shared/styles/token.css.ts';
 
 export const hero = style({
   display: 'flex',
@@ -9,6 +10,7 @@ export const hero = style({
   textAlign: 'center',
   color: '#fff',
   padding: '2rem',
+  transition: 'color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease',
 });
 
 export const title = style({
@@ -16,6 +18,7 @@ export const title = style({
   fontWeight: 'bold',
   lineHeight: 1.2,
   marginBottom: '1.5rem',
+  maxWidth: '768px',
 });
 
 export const description = style({
@@ -30,7 +33,39 @@ export const ctaButton = style({
   padding: '0.75rem 1.5rem',
   color: '#fff',
   cursor: 'pointer',
+  transition: 'background 0.2s ease, box-shadow 0.2s ease',
   ':hover': {
     background: '#2563eb',
+    boxShadow: '0 18px 32px rgba(37, 99, 235, 0.25)',
   },
+});
+
+globalStyle(`.light .${hero}`, {
+  color: lightVars.color.textPrimary,
+  background:
+    'linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(236, 240, 255, 0.94))',
+  borderRadius: '32px',
+  border: `1px solid ${lightVars.color.borderLight}`,
+  boxShadow: '0 32px 64px rgba(159, 176, 231, 0.35)',
+  padding: '3rem 2.5rem',
+  gap: '1.5rem',
+});
+
+globalStyle(`.light .${title}`, {
+  color: lightVars.color.textPrimary,
+});
+
+globalStyle(`.light .${description}`, {
+  color: lightVars.color.textSecondary,
+});
+
+globalStyle(`.light .${ctaButton}`, {
+  background: '#9B1112',
+  color: lightVars.color.textLight,
+  boxShadow: '0 18px 36px rgba(155, 17, 18, 0.25)',
+});
+
+globalStyle(`.light .${ctaButton}:hover`, {
+  background: '#b71516',
+  boxShadow: '0 22px 40px rgba(155, 17, 18, 0.28)',
 });

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,3 +1,23 @@
-export const Home = () => {
-  return <>Home</>;
+import React from 'react';
+import { SideBar } from '@shared/ui/sidebar/SideBar.tsx';
+import { Header } from '@shared/ui/header/Header.tsx';
+import { Footer } from '@shared/ui/footer/Footer.tsx';
+import { Hero } from '@src/components/hero/Hero.tsx';
+import { MainContainer } from '@shared/layout/MainContainer.tsx';
+
+interface HomeProps {
+  appearance: 'light' | 'dark';
+  setAppearance: React.Dispatch<React.SetStateAction<'light' | 'dark'>>;
+}
+
+export const Home = ({ appearance, setAppearance }: HomeProps) => {
+  return (
+    <MainContainer
+      sidebar={<SideBar appearance={appearance} setAppearance={setAppearance} />}
+    >
+      <Header />
+      <Hero />
+      <Footer />
+    </MainContainer>
+  );
 };


### PR DESCRIPTION
## Summary
- add light mode specific styling for the hero section while keeping the existing dark appearance
- replace the placeholder home page with the shared layout, header, hero, and footer used in testing
- route the home path through the new Home page instead of the temporary Test component

## Testing
- yarn lint *(fails: missing eslint package in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68db593e764083319c933989c98f00c2