### PR TITLE
Add centered login page with navigation

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { BoardPage } from '@src/domain/board/pages/BoardPage.tsx';
 import { CardContainer } from '@src/components/card/cardContainer/CardContainer.tsx';
 import { Home } from '@src/pages/home/Home.tsx';
+import { Login } from '@src/pages/login/Login.tsx';
 
 interface RouterProps {
   appearance: 'light' | 'dark';
@@ -26,6 +27,7 @@ export const Router = ({ appearance, setAppearance }: RouterProps) => {
           }
         />
         <Route path="/card" element={<CardContainer />} />
+        <Route path="/login" element={<Login />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -1,0 +1,91 @@
+import { FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as styles from './login.css.ts';
+
+export const LoginForm = () => {
+  const navigate = useNavigate();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // TODO: integrate real login flow
+  };
+
+  const handleSignUp = () => {
+    navigate('/signup');
+  };
+
+  const handleGoogleLogin = () => {
+    // TODO: integrate Google login flow
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <span className={styles.logo}>F1 KOREA</span>
+        <h1 className={styles.title}>로그인</h1>
+        <p className={styles.subtitle}>
+          F1 KOREA와 함께 생생한 그랑프리 현장을 경험해 보세요.
+        </p>
+      </div>
+
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <label className={styles.label}>
+          이메일
+          <input
+            className={styles.input}
+            type="email"
+            name="email"
+            placeholder="이메일을 입력하세요"
+            required
+          />
+        </label>
+
+        <label className={styles.label}>
+          비밀번호
+          <input
+            className={styles.input}
+            type="password"
+            name="password"
+            placeholder="비밀번호를 입력하세요"
+            required
+          />
+        </label>
+
+        <button className={styles.loginButton} type="submit">
+          로그인
+        </button>
+      </form>
+
+      <button className={styles.googleButton} type="button" onClick={handleGoogleLogin}>
+        <span className={styles.googleIcon} aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false">
+            <path
+              d="M21.35 11.1h-9.17v2.95h5.45c-.23 1.43-.94 2.64-2.02 3.46v2.88h3.26c1.91-1.76 3.01-4.36 3.01-7.46 0-.72-.07-1.41-.18-2.08z"
+              fill="#4285F4"
+            />
+            <path
+              d="M12.18 21c2.73 0 5.01-.9 6.68-2.61l-3.26-2.88c-.9.6-2.05.96-3.42.96-2.63 0-4.86-1.77-5.66-4.17H3.12v3.02C4.77 18.82 8.21 21 12.18 21z"
+              fill="#34A853"
+            />
+            <path
+              d="M6.52 12.3c-.2-.6-.32-1.25-.32-1.92 0-.67.12-1.32.32-1.92V5.44H3.12C2.41 6.83 2 8.39 2 10.08c0 1.7.41 3.25 1.12 4.64l3.4-2.42z"
+              fill="#FBBC05"
+            />
+            <path
+              d="M12.18 4.58c1.48 0 2.79.51 3.83 1.5l2.87-2.87C17.18 1.75 14.9.76 12.18.76 8.21.76 4.77 2.94 3.12 6.02l3.4 2.42c.8-2.4 3.03-4.17 5.66-4.17z"
+              fill="#EA4335"
+            />
+          </svg>
+        </span>
+        Google 계정으로 계속하기
+      </button>
+
+      <div className={styles.footer}>
+        <span>아직 계정이 없으신가요?</span>
+        <button className={styles.signUpButton} type="button" onClick={handleSignUp}>
+          회원가입
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/login/login.css.ts
+++ b/src/components/login/login.css.ts
@@ -1,0 +1,224 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+export const container = style({
+  position: 'relative',
+  width: '100%',
+  maxWidth: '420px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '24px',
+  padding: '48px 40px',
+  borderRadius: '28px',
+  background: 'rgba(10, 15, 28, 0.88)',
+  border: '1px solid rgba(63, 77, 126, 0.55)',
+  boxShadow: '0 24px 48px rgba(9, 12, 24, 0.55)',
+  backdropFilter: 'blur(18px)',
+  color: '#f7f9ff',
+  fontFamily: `'Paperozi', sans-serif`,
+});
+
+export const header = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+  textAlign: 'center',
+});
+
+export const logo = style({
+  fontFamily: 'Teko, serif',
+  fontSize: '38px',
+  letterSpacing: '0.08em',
+  color: '#9B1112',
+});
+
+export const title = style({
+  fontSize: '28px',
+  fontWeight: 600,
+});
+
+export const subtitle = style({
+  fontSize: '15px',
+  lineHeight: 1.6,
+  color: 'rgba(203, 209, 255, 0.82)',
+});
+
+export const form = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+});
+
+export const label = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+  fontSize: '14px',
+  color: 'rgba(203, 209, 255, 0.92)',
+});
+
+export const input = style({
+  width: '100%',
+  padding: '14px 16px',
+  borderRadius: '14px',
+  border: '1px solid rgba(102, 120, 189, 0.6)',
+  background: 'rgba(5, 9, 19, 0.78)',
+  color: '#f7f9ff',
+  fontSize: '15px',
+  transition: 'border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease',
+  selectors: {
+    '&::placeholder': {
+      color: 'rgba(149, 163, 216, 0.68)',
+    },
+    '&:focus': {
+      outline: 'none',
+      borderColor: 'rgba(155, 17, 18, 0.6)',
+      boxShadow: '0 0 0 2px rgba(155, 17, 18, 0.28)',
+      background: 'rgba(10, 14, 26, 0.92)',
+    },
+  },
+});
+
+export const loginButton = style({
+  marginTop: '12px',
+  width: '100%',
+  padding: '14px 16px',
+  borderRadius: '14px',
+  border: 'none',
+  cursor: 'pointer',
+  background:
+    'linear-gradient(135deg, rgba(134, 159, 255, 0.26), rgba(91, 114, 196, 0.22))',
+  color: '#ffffff',
+  fontSize: '16px',
+  fontWeight: 600,
+  letterSpacing: '0.04em',
+  boxShadow: '0 18px 32px rgba(39, 58, 147, 0.45)',
+  transition: 'transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease',
+  selectors: {
+    '&:hover': {
+      transform: 'translateY(-1px)',
+      boxShadow: '0 22px 38px rgba(62, 92, 214, 0.42)',
+      background:
+        'linear-gradient(135deg, rgba(155, 17, 18, 0.36), rgba(134, 159, 255, 0.28))',
+    },
+    '&:active': {
+      transform: 'translateY(0)',
+    },
+  },
+});
+
+export const googleButton = style({
+  width: '100%',
+  padding: '12px 16px',
+  borderRadius: '14px',
+  border: '1px solid rgba(141, 150, 196, 0.4)',
+  background: 'rgba(10, 14, 24, 0.62)',
+  color: '#f7f9ff',
+  fontSize: '15px',
+  fontWeight: 500,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '12px',
+  cursor: 'pointer',
+  transition: 'border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease',
+  selectors: {
+    '& svg': {
+      width: '20px',
+      height: '20px',
+    },
+    '&:hover': {
+      borderColor: 'rgba(155, 17, 18, 0.55)',
+      boxShadow: '0 16px 32px rgba(9, 12, 24, 0.45)',
+      background: 'rgba(15, 20, 34, 0.82)',
+    },
+  },
+});
+
+export const googleIcon = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '32px',
+  height: '32px',
+  borderRadius: '50%',
+  background: '#fff',
+  boxShadow: '0 4px 14px rgba(9, 12, 24, 0.4)',
+});
+
+export const footer = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '8px',
+  fontSize: '14px',
+  color: 'rgba(203, 209, 255, 0.82)',
+});
+
+export const signUpButton = style({
+  border: 'none',
+  background: 'none',
+  color: '#9B1112',
+  fontWeight: 600,
+  cursor: 'pointer',
+  padding: 0,
+  selectors: {
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
+});
+
+globalStyle(`.light .${container}`, {
+  background: 'rgba(255, 255, 255, 0.9)',
+  border: '1px solid rgba(184, 196, 233, 0.6)',
+  boxShadow: '0 20px 40px rgba(120, 132, 189, 0.25)',
+  color: '#1C1C1C',
+});
+
+globalStyle(`.light .${subtitle}`, {
+  color: 'rgba(55, 63, 92, 0.7)',
+});
+
+globalStyle(`.light .${label}`, {
+  color: 'rgba(44, 52, 78, 0.92)',
+});
+
+globalStyle(`.light .${input}`, {
+  background: '#ffffff',
+  border: '1px solid rgba(184, 196, 233, 0.7)',
+  color: '#1C1C1C',
+});
+
+globalStyle(`.light .${input}::placeholder`, {
+  color: 'rgba(122, 133, 176, 0.7)',
+});
+
+globalStyle(`.light .${input}:focus`, {
+  border: '1px solid rgba(155, 17, 18, 0.6)',
+  boxShadow: '0 0 0 2px rgba(155, 17, 18, 0.18)',
+  background: '#f8f9ff',
+});
+
+globalStyle(`.light .${loginButton}`, {
+  background:
+    'linear-gradient(135deg, rgba(155, 17, 18, 0.86), rgba(155, 17, 18, 0.74))',
+  boxShadow: '0 18px 38px rgba(155, 17, 18, 0.3)',
+});
+
+globalStyle(`.light .${googleButton}`, {
+  background: '#ffffff',
+  color: '#2f3762',
+  border: '1px solid rgba(184, 196, 233, 0.8)',
+});
+
+globalStyle(`.light .${googleIcon}`, {
+  boxShadow: '0 4px 12px rgba(120, 132, 189, 0.25)',
+});
+
+globalStyle(`.light .${footer}`, {
+  color: 'rgba(55, 63, 92, 0.8)',
+});
+
+globalStyle(`.light .${signUpButton}`, {
+  color: '#9B1112',
+});

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,0 +1,12 @@
+import { LoginForm } from '@src/components/login/LoginForm.tsx';
+import * as styles from './login.css.ts';
+
+export const Login = () => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.primaryGlow} aria-hidden="true" />
+      <div className={styles.secondaryGlow} aria-hidden="true" />
+      <LoginForm />
+    </div>
+  );
+};

--- a/src/pages/login/login.css.ts
+++ b/src/pages/login/login.css.ts
@@ -1,0 +1,53 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+export const container = style({
+  minHeight: '100vh',
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '48px 16px',
+  background:
+    'radial-gradient(120% 140% at 50% 0%, rgba(62, 92, 214, 0.22) 0%, rgba(6, 9, 19, 0.96) 55%, #04060d 100%)',
+  position: 'relative',
+  overflow: 'hidden',
+});
+
+export const primaryGlow = style({
+  position: 'absolute',
+  width: '480px',
+  height: '480px',
+  top: '-120px',
+  right: '-80px',
+  borderRadius: '50%',
+  background:
+    'radial-gradient(circle, rgba(155, 17, 18, 0.35) 0%, rgba(9, 12, 24, 0) 70%)',
+  filter: 'blur(0px)',
+});
+
+export const secondaryGlow = style({
+  position: 'absolute',
+  width: '360px',
+  height: '360px',
+  bottom: '-120px',
+  left: '-60px',
+  borderRadius: '50%',
+  background:
+    'radial-gradient(circle, rgba(62, 92, 214, 0.35) 0%, rgba(9, 12, 24, 0) 72%)',
+  filter: 'blur(0px)',
+});
+
+globalStyle(`.light .${container}`, {
+  background:
+    'radial-gradient(120% 140% at 50% 0%, rgba(255, 210, 214, 0.28) 0%, rgba(247, 249, 255, 0.92) 55%, #f6f7ff 100%)',
+});
+
+globalStyle(`.light .${primaryGlow}`, {
+  background:
+    'radial-gradient(circle, rgba(155, 17, 18, 0.28) 0%, rgba(255, 255, 255, 0) 74%)',
+});
+
+globalStyle(`.light .${secondaryGlow}`, {
+  background:
+    'radial-gradient(circle, rgba(110, 135, 255, 0.26) 0%, rgba(255, 255, 255, 0) 76%)',
+});

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -16,6 +16,10 @@ export const Header = () => {
     navigate('/');
   };
 
+  const handleLoginClick = () => {
+    navigate('/login');
+  };
+
   return (
     <div className={style.box}>
       <div className={style.container}>
@@ -55,7 +59,9 @@ export const Header = () => {
           </Flex>
 
           {/* 오른쪽: 로그인 */}
-          <button className={style.loginButtonStyle}>로그인</button>
+          <button className={style.loginButtonStyle} onClick={handleLoginClick}>
+            로그인
+          </button>
         </Flex>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- create a dedicated login form component with styling aligned to the existing visual language
- add a focused login page that centers the form and prepares Google and sign-up actions
- wire the header button and router so that `/login` is accessible from the main navigation

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db686df9608331b5dbe858aa079ac2