### PR TITLE
Add signup page and integrate routing

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { BoardPage } from '@src/domain/board/pages/BoardPage.tsx';
 import { Home } from '@app/home/Home.tsx';
 import { LoginPage } from '@domain/user/pages/login/LoginPage.tsx';
+import { SignupPage } from '@domain/user/pages/signup/SignupPage.tsx';
 import { GuideGlossaryPage } from '@src/domain/ruleBook/pages/ruleBook/GuideGlossaryPage.tsx';
 import { GuideDetailPage } from '@src/domain/ruleBook/pages/ruleBookDetail/GuideDetailPage.tsx';
 
@@ -46,6 +47,7 @@ export const Router = ({ appearance, setAppearance }: RouterProps) => {
           }
         />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/signup" element={<SignupPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/domain/user/components/signupForm/Signup.tsx
+++ b/src/domain/user/components/signupForm/Signup.tsx
@@ -1,3 +1,0 @@
-export const Signup = () => {
-  return <>Signup</>;
-};

--- a/src/domain/user/components/signupForm/SignupForm.tsx
+++ b/src/domain/user/components/signupForm/SignupForm.tsx
@@ -1,0 +1,109 @@
+import type { FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as styles from './styles/signup.css.ts';
+
+export const SignupForm = () => {
+  const navigate = useNavigate();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // TODO: integrate real signup flow
+  };
+
+  const handleGoToLogin = () => {
+    navigate('/login');
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <span className={styles.logo}>F1 KOREA</span>
+        <div className={styles.titleGroup}>
+          <h1 className={styles.title}>계정을 생성하세요</h1>
+          <p className={styles.subtitle}>
+            신규 계정을 만들고 F1 KOREA의 최신 소식과 콘텐츠를 받아보세요.
+          </p>
+        </div>
+      </div>
+
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <div className={styles.fieldGroup}>
+          <label className={styles.label}>
+            사용자 이름
+            <input
+              className={styles.input}
+              type="text"
+              name="username"
+              placeholder="사용자 이름을 입력하세요"
+              autoComplete="username"
+              required
+            />
+            <span className={styles.helper}>
+              프로필에 표시될 이름으로 50자 이내로 입력해주세요.
+            </span>
+          </label>
+
+          <label className={styles.label}>
+            이메일
+            <input
+              className={styles.input}
+              type="email"
+              name="email"
+              placeholder="이메일을 입력하세요"
+              autoComplete="email"
+              required
+            />
+          </label>
+        </div>
+
+        <div className={styles.fieldGroup}>
+          <label className={styles.label}>
+            비밀번호
+            <input
+              className={styles.input}
+              type="password"
+              name="password"
+              placeholder="비밀번호를 입력하세요"
+              autoComplete="new-password"
+              required
+            />
+          </label>
+
+          <label className={styles.label}>
+            비밀번호 확인
+            <input
+              className={styles.input}
+              type="password"
+              name="passwordConfirm"
+              placeholder="비밀번호를 다시 입력하세요"
+              autoComplete="new-password"
+              required
+            />
+          </label>
+
+          <div className={styles.passwordHint}>
+            <span className={styles.hintTitle}>안전한 비밀번호 가이드</span>
+            <ul className={styles.hintList}>
+              <li>8자 이상 입력해주세요.</li>
+              <li>영문 대소문자, 숫자, 특수문자를 조합하면 더욱 안전합니다.</li>
+              <li>다른 사이트에서 사용 중인 비밀번호는 피해주세요.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div className={styles.actions}>
+          <button className={styles.submitButton} type="submit">
+            회원가입
+          </button>
+        </div>
+      </form>
+
+      <div className={styles.footer}>
+        <span>이미 계정이 있으신가요?</span>
+        <button className={styles.loginButton} type="button" onClick={handleGoToLogin}>
+          로그인
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/domain/user/components/signupForm/styles/signup.css.ts
+++ b/src/domain/user/components/signupForm/styles/signup.css.ts
@@ -1,0 +1,233 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+export const container = style({
+  position: 'relative',
+  width: '100%',
+  maxWidth: '460px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '24px',
+  padding: '52px 44px',
+  borderRadius: '30px',
+  background: 'rgba(10, 15, 28, 0.9)',
+  border: '1px solid rgba(63, 77, 126, 0.55)',
+  boxShadow: '0 26px 52px rgba(9, 12, 24, 0.55)',
+  backdropFilter: 'blur(20px)',
+  color: '#f7f9ff',
+  fontFamily: `'Paperozi', sans-serif`,
+});
+
+export const header = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+  textAlign: 'center',
+});
+
+export const logo = style({
+  fontFamily: 'Teko, serif',
+  fontSize: '38px',
+  letterSpacing: '0.08em',
+  color: '#9B1112',
+});
+
+export const titleGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+});
+
+export const title = style({
+  fontSize: '28px',
+  fontWeight: 600,
+});
+
+export const subtitle = style({
+  fontSize: '15px',
+  lineHeight: 1.6,
+  color: 'rgba(203, 209, 255, 0.82)',
+});
+
+export const form = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '18px',
+});
+
+export const fieldGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+});
+
+export const label = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+  fontSize: '14px',
+  color: 'rgba(203, 209, 255, 0.92)',
+});
+
+export const input = style({
+  padding: '12px 10px',
+  borderRadius: '14px',
+  border: '1px solid rgba(102, 120, 189, 0.6)',
+  background: 'rgba(5, 9, 19, 0.8)',
+  color: '#f7f9ff',
+  fontSize: '15px',
+  transition:
+    'border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, transform 0.2s ease',
+  selectors: {
+    '&::placeholder': {
+      color: 'rgba(149, 163, 216, 0.68)',
+    },
+    '&:focus': {
+      outline: 'none',
+      borderColor: 'rgba(155, 17, 18, 0.6)',
+      boxShadow: '0 0 0 2px rgba(155, 17, 18, 0.28)',
+      background: 'rgba(10, 14, 26, 0.92)',
+      transform: 'translateY(-1px)',
+    },
+  },
+});
+
+export const helper = style({
+  fontSize: '12px',
+  lineHeight: 1.5,
+  color: 'rgba(149, 163, 216, 0.75)',
+});
+
+export const passwordHint = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6px',
+  padding: '14px 16px',
+  borderRadius: '16px',
+  background: 'rgba(23, 30, 55, 0.55)',
+  border: '1px solid rgba(63, 77, 126, 0.45)',
+});
+
+export const hintTitle = style({
+  fontSize: '13px',
+  fontWeight: 600,
+  color: 'rgba(203, 209, 255, 0.85)',
+});
+
+export const hintList = style({
+  margin: 0,
+  paddingLeft: '18px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+  color: 'rgba(149, 163, 216, 0.75)',
+  fontSize: '12px',
+  lineHeight: 1.5,
+});
+
+export const actions = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+  marginTop: '4px',
+});
+
+export const submitButton = style({
+  width: '100%',
+  height: '48px',
+  padding: '12px 8px',
+  borderRadius: '16px',
+  border: 'none',
+  cursor: 'pointer',
+  background:
+    'linear-gradient(135deg, rgba(134, 159, 255, 0.26), rgba(91, 114, 196, 0.22))',
+  color: '#ffffff',
+  fontSize: '16px',
+  fontWeight: 600,
+  letterSpacing: '0.04em',
+  transition: 'transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease',
+  selectors: {
+    '&:hover': {
+      transform: 'translateY(-1px)',
+      background:
+        'linear-gradient(135deg, rgba(155, 17, 18, 0.36), rgba(134, 159, 255, 0.28))',
+    },
+    '&:active': {
+      transform: 'translateY(0)',
+    },
+  },
+});
+
+export const footer = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '8px',
+  fontSize: '14px',
+  color: 'rgba(203, 209, 255, 0.82)',
+});
+
+export const loginButton = style({
+  border: 'none',
+  background: 'none',
+  color: '#9B1112',
+  fontWeight: 600,
+  cursor: 'pointer',
+  padding: 0,
+  selectors: {
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
+});
+
+globalStyle(`.light .${container}`, {
+  background: 'rgba(255, 255, 255, 0.92)',
+  border: '1px solid rgba(184, 196, 233, 0.6)',
+  boxShadow: '0 22px 44px rgba(120, 132, 189, 0.24)',
+  color: '#1C1C1C',
+});
+
+globalStyle(`.light .${subtitle}`, {
+  color: 'rgba(55, 63, 92, 0.7)',
+});
+
+globalStyle(`.light .${label}`, {
+  color: 'rgba(44, 52, 78, 0.92)',
+});
+
+globalStyle(`.light .${input}`, {
+  background: '#ffffff',
+  border: '1px solid rgba(184, 196, 233, 0.7)',
+  color: '#1C1C1C',
+});
+
+globalStyle(`.light .${input}::placeholder`, {
+  color: 'rgba(122, 133, 176, 0.7)',
+});
+
+globalStyle(`.light .${input}:focus`, {
+  border: '1px solid rgba(155, 17, 18, 0.55)',
+  boxShadow: '0 0 0 2px rgba(155, 17, 18, 0.18)',
+  background: '#f8f9ff',
+});
+
+globalStyle(`.light .${passwordHint}`, {
+  background: 'rgba(244, 246, 255, 0.85)',
+  border: '1px solid rgba(184, 196, 233, 0.6)',
+});
+
+globalStyle(`.light .${hintTitle}`, {
+  color: 'rgba(55, 63, 92, 0.8)',
+});
+
+globalStyle(`.light .${hintList}`, {
+  color: 'rgba(93, 105, 152, 0.8)',
+});
+
+globalStyle(`.light .${footer}`, {
+  color: 'rgba(55, 63, 92, 0.8)',
+});
+
+globalStyle(`.light .${loginButton}`, {
+  color: '#9B1112',
+});

--- a/src/domain/user/pages/signup/SignupPage.tsx
+++ b/src/domain/user/pages/signup/SignupPage.tsx
@@ -1,3 +1,12 @@
+import { SignupForm } from '@domain/user/components/signupForm/SignupForm.tsx';
+import * as styles from '../../styles/signup/signup.css.ts';
+
 export const SignupPage = () => {
-  return <>signup page</>;
+  return (
+    <div className={styles.container}>
+      <div className={styles.primaryGlow} aria-hidden="true" />
+      <div className={styles.secondaryGlow} aria-hidden="true" />
+      <SignupForm />
+    </div>
+  );
 };

--- a/src/domain/user/styles/signup/signup.css.ts
+++ b/src/domain/user/styles/signup/signup.css.ts
@@ -1,0 +1,53 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+export const container = style({
+  minHeight: '100vh',
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '48px 16px',
+  background:
+    'radial-gradient(120% 140% at 50% 0%, rgba(62, 92, 214, 0.18) 0%, rgba(6, 9, 19, 0.95) 55%, #05070f 100%)',
+  position: 'relative',
+  overflow: 'hidden',
+});
+
+export const primaryGlow = style({
+  position: 'absolute',
+  width: '520px',
+  height: '520px',
+  top: '-140px',
+  right: '-120px',
+  borderRadius: '50%',
+  background:
+    'radial-gradient(circle, rgba(155, 17, 18, 0.32) 0%, rgba(9, 12, 24, 0) 70%)',
+  filter: 'blur(0px)',
+});
+
+export const secondaryGlow = style({
+  position: 'absolute',
+  width: '380px',
+  height: '380px',
+  bottom: '-140px',
+  left: '-80px',
+  borderRadius: '50%',
+  background:
+    'radial-gradient(circle, rgba(134, 159, 255, 0.3) 0%, rgba(9, 12, 24, 0) 72%)',
+  filter: 'blur(0px)',
+});
+
+globalStyle(`.light .${container}`, {
+  background:
+    'radial-gradient(120% 140% at 50% 0%, rgba(255, 210, 214, 0.32) 0%, rgba(247, 249, 255, 0.9) 55%, #f6f7ff 100%)',
+});
+
+globalStyle(`.light .${primaryGlow}`, {
+  background:
+    'radial-gradient(circle, rgba(155, 17, 18, 0.24) 0%, rgba(255, 255, 255, 0) 74%)',
+});
+
+globalStyle(`.light .${secondaryGlow}`, {
+  background:
+    'radial-gradient(circle, rgba(110, 135, 255, 0.24) 0%, rgba(255, 255, 255, 0) 76%)',
+});


### PR DESCRIPTION
## Summary
- create a dedicated signup page layout with matching background effects
- implement the signup form with username, email, and password fields plus helper guidance
- register the signup route so navigation from the login page reaches the new screen

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68de0133e6f48331935ab29de2257001