### PR TITLE
Add safety car card to rule book detail sidebar

### DIFF
--- a/src/domain/ruleBook/pages/ruleBookDetail/GuideDetailPage.tsx
+++ b/src/domain/ruleBook/pages/ruleBookDetail/GuideDetailPage.tsx
@@ -6,6 +6,7 @@ import { Header } from '@shared/ui/header/Header.tsx';
 import { Footer } from '@shared/ui/footer/Footer.tsx';
 import { findGlossaryTerm } from '@src/domain/ruleBook/data/glossary.ts';
 import * as styles from '@domain/ruleBook/styles/ruleBookDetail/guideDetailPage.css.ts';
+import safetyCarImage from '@domain/ruleBook/img/safetyCar.png';
 
 interface GuideDetailPageProps {
   appearance: 'light' | 'dark';
@@ -79,6 +80,13 @@ export const GuideDetailPage = ({
               </section>
 
               <aside className={styles.sidebarPanel}>
+                <div className={styles.quickFactsImageCard}>
+                  <img
+                    src={safetyCarImage}
+                    alt="Safety car"
+                    className={styles.quickFactsImage}
+                  />
+                </div>
                 <div className={styles.quickFacts}>
                   <h2 className={styles.quickFactsTitle}>Quick Facts</h2>
                   {term.quickFacts.map((fact) => (

--- a/src/domain/ruleBook/styles/ruleBookDetail/guideDetailPage.css.ts
+++ b/src/domain/ruleBook/styles/ruleBookDetail/guideDetailPage.css.ts
@@ -136,6 +136,31 @@ export const sidebarPanel = style({
   gap: 20,
 });
 
+export const quickFactsImageCard = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: 20,
+  padding: '28px 32px',
+  background: 'rgba(12, 17, 34, 0.9)',
+  border: '1px solid rgba(84, 106, 184, 0.48)',
+  boxShadow: '0 20px 32px rgba(6, 10, 24, 0.48)',
+  overflow: 'hidden',
+  selectors: {
+    ':root.light &': {
+      background: '#f7f8ff',
+      border: '1px solid rgba(102, 118, 212, 0.28)',
+      boxShadow: '0 18px 32px rgba(82, 102, 206, 0.12)',
+    },
+  },
+});
+
+export const quickFactsImage = style({
+  width: '100%',
+  height: '100%',
+  objectFit: 'contain',
+});
+
 export const quickFacts = style({
   borderRadius: 20,
   padding: '28px 32px',


### PR DESCRIPTION
## Summary
- add a safety car image card above the Quick Facts list in the rule book detail sidebar
- style the new card to mirror the existing Quick Facts panel in both light and dark themes

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68df84c8ad7083318aa416417b170709