### PR TITLE
feat: add 2025 race calendar

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -7,6 +7,7 @@ import { SignupPage } from '@domain/user/pages/signup/SignupPage.tsx';
 import { GuideGlossaryPage } from '@src/domain/ruleBook/pages/ruleBook/GuideGlossaryPage.tsx';
 import { GuideDetailPage } from '@src/domain/ruleBook/pages/ruleBookDetail/GuideDetailPage.tsx';
 import { BoardDetailPage } from '@domain/board/pages/boardDetail/boardDetailPages.tsx';
+import { CalanderPage } from '@domain/calander/pages/calanderPage.tsx';
 
 interface RouterProps {
   appearance: 'light' | 'dark';
@@ -51,6 +52,24 @@ export const Router = ({ appearance, setAppearance }: RouterProps) => {
           path="/guide/:slug"
           element={
             <GuideDetailPage
+              appearance={appearance}
+              setAppearance={setAppearance}
+            />
+          }
+        />
+        <Route
+          path="/calendar"
+          element={
+            <CalanderPage
+              appearance={appearance}
+              setAppearance={setAppearance}
+            />
+          }
+        />
+        <Route
+          path="/calendar/:slug"
+          element={
+            <CalanderPage
               appearance={appearance}
               setAppearance={setAppearance}
             />

--- a/src/domain/calander/calanderDetail/calanderDetail.css.ts
+++ b/src/domain/calander/calanderDetail/calanderDetail.css.ts
@@ -1,0 +1,155 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 28,
+  padding: '32px 32px 36px',
+  borderRadius: 24,
+  background: 'rgba(10, 14, 26, 0.9)',
+  border: '1px solid rgba(70, 88, 138, 0.45)',
+  boxShadow: '0 26px 52px rgba(6, 10, 22, 0.55)',
+  minHeight: 320,
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(247, 249, 255, 0.96)',
+      border: '1px solid rgba(132, 150, 212, 0.42)',
+      boxShadow: '0 24px 52px rgba(104, 126, 220, 0.2)',
+    },
+  },
+});
+
+export const placeholder = style({
+  margin: 0,
+  fontSize: 15,
+  color: 'rgba(190, 202, 240, 0.72)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(46, 58, 104, 0.58)',
+    },
+  },
+});
+
+export const header = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+});
+
+export const label = style({
+  fontSize: 12,
+  letterSpacing: '0.3em',
+  textTransform: 'uppercase',
+  color: 'rgba(125, 146, 220, 0.7)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(54, 70, 128, 0.65)',
+    },
+  },
+});
+
+export const title = style({
+  margin: 0,
+  fontSize: 26,
+  fontWeight: 700,
+  letterSpacing: '-0.01em',
+  color: '#f6f8ff',
+  selectors: {
+    ':root.light &': {
+      color: '#121831',
+    },
+  },
+});
+
+export const meta = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 12,
+  fontSize: 14,
+  color: 'rgba(196, 208, 242, 0.75)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(44, 58, 102, 0.7)',
+    },
+  },
+});
+
+export const metaDivider = style({
+  opacity: 0.5,
+});
+
+export const sectionHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+export const sectionTitle = style({
+  margin: 0,
+  fontSize: 18,
+  fontWeight: 600,
+  color: '#f0f3ff',
+  selectors: {
+    ':root.light &': {
+      color: '#1b243f',
+    },
+  },
+});
+
+export const sessionList = style({
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+});
+
+export const sessionItem = style({
+  display: 'grid',
+  gridTemplateColumns: '180px minmax(0, 1fr)',
+  alignItems: 'center',
+  gap: 18,
+  padding: '14px 0',
+  borderBottom: '1px solid rgba(76, 92, 142, 0.35)',
+  selectors: {
+    '&:last-child': {
+      borderBottom: 'none',
+    },
+    ':root.light &': {
+      borderBottom: '1px solid rgba(142, 158, 210, 0.28)',
+    },
+  },
+});
+
+export const sessionLabel = style({
+  fontSize: 15,
+  fontWeight: 600,
+  color: '#f5f7ff',
+  letterSpacing: '-0.01em',
+  selectors: {
+    ':root.light &': {
+      color: '#1a213a',
+    },
+  },
+});
+
+export const sessionTime = style({
+  fontSize: 14,
+  color: 'rgba(196, 208, 242, 0.78)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(54, 66, 110, 0.72)',
+    },
+  },
+});
+
+export const sessionDuration = style({
+  fontSize: 12,
+  color: 'rgba(160, 178, 228, 0.65)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(66, 78, 120, 0.58)',
+    },
+  },
+});

--- a/src/domain/calander/calanderDetail/calanderDetail.tsx
+++ b/src/domain/calander/calanderDetail/calanderDetail.tsx
@@ -1,0 +1,154 @@
+import React, { useMemo } from 'react';
+import type { CalanderEvent, CalanderSession } from '@domain/calander/data/calander.ts';
+import * as styles from './calanderDetail.css.ts';
+
+const KOREA_TIMEZONE = 'Asia/Seoul';
+
+const formatDateRange = (startIso: string, endIso: string) => {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return '';
+  }
+
+  const startLabel = start.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    timeZone: KOREA_TIMEZONE,
+  });
+  const endLabel = end.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    timeZone: KOREA_TIMEZONE,
+  });
+
+  return `${startLabel} ~ ${endLabel}`;
+};
+
+const formatSessionRange = (session: CalanderSession) => {
+  const start = new Date(session.start);
+  const end = new Date(session.end);
+
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return { window: '', duration: '' };
+  }
+
+  const startDateLabel = start.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    timeZone: KOREA_TIMEZONE,
+  });
+  const endDateLabel = end.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    timeZone: KOREA_TIMEZONE,
+  });
+
+  const startTimeLabel = start.toLocaleTimeString('ko-KR', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: KOREA_TIMEZONE,
+  });
+  const endTimeLabel = end.toLocaleTimeString('ko-KR', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: KOREA_TIMEZONE,
+  });
+
+  const sameDay = startDateLabel === endDateLabel;
+  const window = sameDay
+    ? `${startDateLabel} ${startTimeLabel} ~ ${endTimeLabel}`
+    : `${startDateLabel} ${startTimeLabel} ~ ${endDateLabel} ${endTimeLabel}`;
+
+  const durationMinutes = Math.max(
+    0,
+    Math.round((end.getTime() - start.getTime()) / 60000)
+  );
+
+  const hours = Math.floor(durationMinutes / 60);
+  const minutes = durationMinutes % 60;
+  const durationParts = [] as string[];
+
+  if (hours) {
+    durationParts.push(`${hours}시간`);
+  }
+  if (minutes) {
+    durationParts.push(`${minutes}분`);
+  }
+
+  return {
+    window,
+    duration: durationParts.join(' '),
+  };
+};
+
+interface CalanderDetailProps {
+  event?: CalanderEvent;
+}
+
+export const CalanderDetail = ({ event }: CalanderDetailProps) => {
+  const dateRange = useMemo(() => {
+    if (!event) {
+      return '';
+    }
+    return formatDateRange(event.startDate, event.endDate);
+  }, [event]);
+
+  if (!event) {
+    return (
+      <section className={styles.container} aria-label="선택된 일정 없음">
+        <p className={styles.placeholder}>
+          확인하고 싶은 그랑프리를 선택하면 세부 일정이 표시됩니다.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.container} aria-labelledby={`${event.slug}-title`}>
+      <header className={styles.header}>
+        <span className={styles.label}>FORMULA 1</span>
+        <h2 id={`${event.slug}-title`} className={styles.title}>
+          {event.eventName.toUpperCase()}
+        </h2>
+        <div className={styles.meta}>
+          <span>{dateRange}</span>
+          <span className={styles.metaDivider}>•</span>
+          <span>
+            {event.country} / {event.locality} / {event.circuit}
+          </span>
+        </div>
+      </header>
+
+      <div>
+        <div className={styles.sectionHeader}>
+          <h3 className={styles.sectionTitle}>세션 일정</h3>
+          <span className={styles.sessionDuration}>시간은 한국 기준(KST)입니다.</span>
+        </div>
+        <ul className={styles.sessionList}>
+          {event.sessions.map((session) => {
+            const { window, duration } = formatSessionRange(session);
+            return (
+              <li key={`${event.slug}-${session.type}`} className={styles.sessionItem}>
+                <div>
+                  <span className={styles.sessionLabel}>{session.label}</span>
+                  {duration ? (
+                    <div className={styles.sessionDuration}>{duration}</div>
+                  ) : null}
+                </div>
+                <span className={styles.sessionTime}>{window}</span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+};

--- a/src/domain/calander/calanderList/calanderList.css.ts
+++ b/src/domain/calander/calanderList/calanderList.css.ts
@@ -1,0 +1,83 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 18,
+  padding: '28px 24px',
+  borderRadius: 24,
+  background: 'rgba(9, 13, 24, 0.88)',
+  border: '1px solid rgba(64, 82, 132, 0.4)',
+  boxShadow: '0 26px 48px rgba(6, 10, 22, 0.55)',
+  minWidth: 0,
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(245, 248, 255, 0.95)',
+      border: '1px solid rgba(138, 154, 220, 0.42)',
+      boxShadow: '0 22px 48px rgba(100, 122, 210, 0.18)',
+    },
+  },
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+export const title = style({
+  margin: 0,
+  fontSize: 20,
+  fontWeight: 700,
+  color: '#f2f5ff',
+  letterSpacing: '-0.01em',
+  selectors: {
+    ':root.light &': {
+      color: '#141b34',
+    },
+  },
+});
+
+export const subtitle = style({
+  margin: 0,
+  fontSize: 13,
+  color: 'rgba(194, 206, 245, 0.75)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(38, 52, 92, 0.6)',
+    },
+  },
+});
+
+export const list = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 14,
+  maxHeight: 'calc(100vh - 280px)',
+  overflowY: 'auto',
+  paddingRight: 6,
+});
+
+export const empty = style({
+  padding: '48px 0',
+  textAlign: 'center',
+  fontSize: 14,
+  color: 'rgba(180, 194, 240, 0.68)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(38, 52, 92, 0.5)',
+    },
+  },
+});
+
+export const stickyCount = style({
+  fontSize: 12,
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
+  color: 'rgba(125, 144, 210, 0.75)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(60, 78, 138, 0.75)',
+    },
+  },
+});

--- a/src/domain/calander/calanderList/calanderList.tsx
+++ b/src/domain/calander/calanderList/calanderList.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import type { CalanderEvent } from '@domain/calander/data/calander.ts';
+import { CalanderCard } from '@domain/calander/components/calanderCard/CalanderCard.tsx';
+import * as styles from './calanderList.css.ts';
+
+interface CalanderListProps {
+  events: CalanderEvent[];
+  selectedSlug: string;
+  onSelect: (slug: string) => void;
+}
+
+export const CalanderList = ({
+  events,
+  selectedSlug,
+  onSelect,
+}: CalanderListProps) => {
+  const total = events.length;
+
+  return (
+    <section className={styles.container} aria-label="레이스 캘린더 목록">
+      <div className={styles.header}>
+        <div>
+          <span className={styles.stickyCount}>GP CALENDAR</span>
+          <h2 className={styles.title}>2025 시즌 일정</h2>
+        </div>
+        <p className={styles.subtitle}>총 {total}개 그랑프리</p>
+      </div>
+
+      {total === 0 ? (
+        <p className={styles.empty}>등록된 일정이 없습니다.</p>
+      ) : (
+        <div className={styles.list}>
+          {events.map((event) => (
+            <CalanderCard
+              key={event.slug}
+              event={event}
+              isSelected={event.slug === selectedSlug}
+              onSelect={() => onSelect(event.slug)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/domain/calander/components/calanderCard/CalanderCard.tsx
+++ b/src/domain/calander/components/calanderCard/CalanderCard.tsx
@@ -1,0 +1,109 @@
+import React, { useMemo } from 'react';
+import type { CalanderEvent } from '@domain/calander/data/calander.ts';
+import * as styles from './calanderCard.css.ts';
+
+type EventStatus = 'upcoming' | 'live' | 'completed';
+
+const STATUS_LABEL: Record<EventStatus, string> = {
+  upcoming: '진행 예정',
+  live: '진행 중',
+  completed: '종료',
+};
+
+const getEventStatus = (event: CalanderEvent): EventStatus => {
+  const now = Date.now();
+  const start = new Date(event.startDate).getTime();
+  const end = new Date(event.endDate).getTime();
+
+  if (Number.isNaN(start) || Number.isNaN(end)) {
+    return 'upcoming';
+  }
+
+  if (now < start) {
+    return 'upcoming';
+  }
+
+  if (now > end) {
+    return 'completed';
+  }
+
+  return 'live';
+};
+
+const formatDateTime = (iso: string) => {
+  const date = new Date(iso);
+
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  const datePart = date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    timeZone: 'Asia/Seoul',
+  });
+
+  const timePart = date.toLocaleTimeString('ko-KR', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: 'Asia/Seoul',
+  });
+
+  return `${datePart} ${timePart} ~`;
+};
+
+interface CalanderCardProps {
+  event: CalanderEvent;
+  isSelected?: boolean;
+  onSelect?: (event: CalanderEvent) => void;
+}
+
+export const CalanderCard = ({ event, isSelected = false, onSelect }: CalanderCardProps) => {
+  const status = useMemo(() => getEventStatus(event), [event]);
+  const formattedRaceStart = useMemo(
+    () => formatDateTime(event.raceStart),
+    [event.raceStart]
+  );
+
+  const handleClick = () => {
+    onSelect?.(event);
+  };
+
+  const className = [styles.card, isSelected ? styles.selected : '']
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={handleClick}
+      aria-pressed={isSelected}
+    >
+      <div className={styles.round}>
+        <span className={styles.roundLabel}>라운드</span>
+        <span className={styles.roundNumber}>{event.round}</span>
+      </div>
+
+      <div className={styles.info}>
+        <div className={styles.locationRow}>
+          <span className={styles.flag} aria-hidden>
+            {event.flag}
+          </span>
+          <span>
+            {event.country} / {event.locality}
+          </span>
+        </div>
+        <h3 className={styles.title}>{event.eventName}</h3>
+        <p className={styles.circuit}>{event.circuit}</p>
+      </div>
+
+      <div className={styles.trailing}>
+        <span className={styles.statusBadge[status]}>{STATUS_LABEL[status]}</span>
+        <span className={styles.dateText}>{formattedRaceStart}</span>
+      </div>
+    </button>
+  );
+};

--- a/src/domain/calander/components/calanderCard/calanderCard.css.ts
+++ b/src/domain/calander/components/calanderCard/calanderCard.css.ts
@@ -1,0 +1,180 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+export const card = style({
+  display: 'grid',
+  gridTemplateColumns: '80px minmax(0, 1fr) auto',
+  gap: 20,
+  alignItems: 'center',
+  padding: '18px 24px',
+  borderRadius: 20,
+  background: 'rgba(13, 19, 35, 0.9)',
+  border: '1px solid rgba(72, 96, 156, 0.36)',
+  color: '#e7ecff',
+  cursor: 'pointer',
+  transition:
+    'background 0.3s ease, border-color 0.3s ease, transform 0.2s ease, box-shadow 0.2s ease',
+  selectors: {
+    '&:hover': {
+      borderColor: 'rgba(110, 140, 220, 0.6)',
+      boxShadow: '0 18px 38px rgba(12, 18, 32, 0.45)',
+      transform: 'translateY(-2px)',
+    },
+    ':root.light &': {
+      background: 'rgba(247, 249, 255, 0.95)',
+      border: '1px solid rgba(145, 164, 228, 0.35)',
+      color: '#17203d',
+      boxShadow: '0 14px 32px rgba(106, 126, 210, 0.18)',
+    },
+    ':root.light &:hover': {
+      borderColor: 'rgba(107, 132, 210, 0.65)',
+      boxShadow: '0 20px 44px rgba(120, 145, 230, 0.24)',
+    },
+  },
+});
+
+export const selected = style({
+  background: 'linear-gradient(135deg, rgba(69, 102, 235, 0.85), rgba(32, 56, 150, 0.9))',
+  borderColor: 'rgba(123, 153, 255, 0.9)',
+  boxShadow: '0 24px 40px rgba(46, 78, 198, 0.55)',
+  selectors: {
+    ':root.light &': {
+      background: 'linear-gradient(135deg, rgba(125, 150, 255, 0.92), rgba(77, 111, 240, 0.9))',
+      color: '#ffffff',
+      boxShadow: '0 24px 48px rgba(104, 132, 245, 0.36)',
+    },
+  },
+});
+
+export const round = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  justifyContent: 'center',
+  gap: 6,
+});
+
+export const roundLabel = style({
+  fontSize: 12,
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
+  opacity: 0.7,
+});
+
+export const roundNumber = style({
+  fontSize: 28,
+  fontWeight: 700,
+  letterSpacing: '-0.02em',
+});
+
+export const info = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  minWidth: 0,
+});
+
+export const locationRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  fontSize: 14,
+  color: 'rgba(216, 224, 255, 0.78)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(38, 52, 92, 0.75)',
+    },
+  },
+});
+
+export const title = style({
+  margin: 0,
+  fontSize: 18,
+  fontWeight: 700,
+  letterSpacing: '-0.01em',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
+export const circuit = style({
+  margin: 0,
+  fontSize: 13,
+  color: 'rgba(183, 196, 240, 0.72)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(38, 52, 92, 0.6)',
+    },
+  },
+});
+
+export const trailing = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+  gap: 8,
+});
+
+export const statusBadge = styleVariants({
+  upcoming: {
+    padding: '6px 12px',
+    borderRadius: 999,
+    background: 'rgba(56, 178, 89, 0.18)',
+    color: '#74f0a6',
+    fontSize: 12,
+    fontWeight: 600,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    selectors: {
+      ':root.light &': {
+        background: 'rgba(63, 178, 110, 0.18)',
+        color: '#1c6d3a',
+      },
+    },
+  },
+  live: {
+    padding: '6px 12px',
+    borderRadius: 999,
+    background: 'rgba(58, 132, 247, 0.22)',
+    color: '#99beff',
+    fontSize: 12,
+    fontWeight: 600,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    selectors: {
+      ':root.light &': {
+        background: 'rgba(74, 116, 242, 0.18)',
+        color: '#2040a3',
+      },
+    },
+  },
+  completed: {
+    padding: '6px 12px',
+    borderRadius: 999,
+    background: 'rgba(120, 132, 162, 0.22)',
+    color: 'rgba(210, 216, 236, 0.78)',
+    fontSize: 12,
+    fontWeight: 600,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    selectors: {
+      ':root.light &': {
+        background: 'rgba(146, 155, 185, 0.22)',
+        color: '#39425f',
+      },
+    },
+  },
+});
+
+export const dateText = style({
+  fontSize: 13,
+  color: 'rgba(186, 198, 240, 0.72)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(38, 52, 92, 0.6)',
+    },
+  },
+});
+
+export const flag = style({
+  fontSize: 18,
+});

--- a/src/domain/calander/data/calander.ts
+++ b/src/domain/calander/data/calander.ts
@@ -1,0 +1,1158 @@
+import type { TrackInfo } from '@domain/calander/data/trackMap.ts';
+
+export type CalanderSessionType =
+  | 'practice1'
+  | 'practice2'
+  | 'practice3'
+  | 'qualifying'
+  | 'sprint'
+  | 'sprintShootout'
+  | 'race';
+
+export interface CalanderSession {
+  type: CalanderSessionType;
+  label: string;
+  start: string;
+  end: string;
+}
+
+export interface CalanderEvent {
+  slug: TrackInfo['slug'];
+  round: number;
+  country: string;
+  locality: string;
+  flag: string;
+  eventName: string;
+  circuit: string;
+  timeZone: string;
+  offset: number;
+  raceStart: string;
+  raceEnd: string;
+  startDate: string;
+  endDate: string;
+  sessions: CalanderSession[];
+}
+
+type LocalDateInput = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute?: number;
+};
+
+type SessionTemplate = {
+  type: CalanderSessionType;
+  label: string;
+  localTime: LocalDateInput;
+  durationMinutes: number;
+};
+
+const toUtcIsoString = (local: LocalDateInput, offset: number) => {
+  const minutes = local.minute ?? 0;
+  const date = new Date(
+    Date.UTC(
+      local.year,
+      local.month - 1,
+      local.day,
+      local.hour - offset,
+      minutes
+    )
+  );
+
+  return date.toISOString();
+};
+
+const addMinutes = (iso: string, duration: number) => {
+  const date = new Date(iso);
+  date.setMinutes(date.getMinutes() + duration);
+  return date.toISOString();
+};
+
+const createSessions = (sessions: SessionTemplate[], offset: number) =>
+  sessions.map((session) => {
+    const start = toUtcIsoString(session.localTime, offset);
+    return {
+      type: session.type,
+      label: session.label,
+      start,
+      end: addMinutes(start, session.durationMinutes),
+    } satisfies CalanderSession;
+  });
+
+interface CreateEventParams {
+  slug: TrackInfo['slug'];
+  round: number;
+  country: string;
+  locality: string;
+  flag: string;
+  circuit: string;
+  eventName: string;
+  timeZone: string;
+  offset: number;
+  sessions: SessionTemplate[];
+}
+
+const createEvent = (params: CreateEventParams): CalanderEvent => {
+  const sessions = createSessions(params.sessions, params.offset);
+  const race = sessions.find((session) => session.type === 'race');
+
+  if (!race) {
+    throw new Error(`Race session missing for ${params.slug}`);
+  }
+
+  return {
+    slug: params.slug,
+    round: params.round,
+    country: params.country,
+    locality: params.locality,
+    flag: params.flag,
+    circuit: params.circuit,
+    eventName: params.eventName,
+    timeZone: params.timeZone,
+    offset: params.offset,
+    raceStart: race.start,
+    raceEnd: race.end,
+    startDate: sessions[0]?.start ?? race.start,
+    endDate: race.end,
+    sessions,
+  };
+};
+
+export const calanderEvents: CalanderEvent[] = [
+  createEvent({
+    slug: 'australian-grand-prix',
+    round: 1,
+    country: 'Australia',
+    locality: 'Melbourne',
+    flag: '🇦🇺',
+    circuit: 'Albert Park Circuit',
+    eventName: '2025 Australian Grand Prix',
+    timeZone: 'Australia/Melbourne',
+    offset: 11,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 3, day: 14, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 3, day: 14, hour: 16, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 3, day: 15, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 3, day: 15, hour: 16, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 3, day: 16, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'chinese-grand-prix',
+    round: 2,
+    country: 'China',
+    locality: 'Shanghai',
+    flag: '🇨🇳',
+    circuit: 'Shanghai International Circuit',
+    eventName: '2025 Chinese Grand Prix',
+    timeZone: 'Asia/Shanghai',
+    offset: 8,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 3, day: 21, hour: 11, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 3, day: 21, hour: 15, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 3, day: 22, hour: 12, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 3, day: 22, hour: 15, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 3, day: 23, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'japanese-grand-prix',
+    round: 3,
+    country: 'Japan',
+    locality: 'Suzuka',
+    flag: '🇯🇵',
+    circuit: 'Suzuka International Racing Course',
+    eventName: '2025 Japanese Grand Prix',
+    timeZone: 'Asia/Tokyo',
+    offset: 9,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 4, day: 4, hour: 11, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 4, day: 4, hour: 15, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 4, day: 5, hour: 11, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 4, day: 5, hour: 15, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 4, day: 6, hour: 14, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'bahrain-grand-prix',
+    round: 4,
+    country: 'Bahrain',
+    locality: 'Sakhir',
+    flag: '🇧🇭',
+    circuit: 'Bahrain International Circuit',
+    eventName: '2025 Bahrain Grand Prix',
+    timeZone: 'Asia/Bahrain',
+    offset: 3,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 4, day: 11, hour: 14, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 4, day: 11, hour: 18, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 4, day: 12, hour: 15, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 4, day: 12, hour: 18, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 4, day: 13, hour: 18, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'saudi-arabian-grand-prix',
+    round: 5,
+    country: 'Saudi Arabia',
+    locality: 'Jeddah',
+    flag: '🇸🇦',
+    circuit: 'Jeddah Corniche Circuit',
+    eventName: '2025 Saudi Arabian Grand Prix',
+    timeZone: 'Asia/Riyadh',
+    offset: 3,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 4, day: 18, hour: 16, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 4, day: 18, hour: 20, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 4, day: 19, hour: 17, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 4, day: 19, hour: 20, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 4, day: 20, hour: 20, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'miami-grand-prix',
+    round: 6,
+    country: 'United States',
+    locality: 'Miami',
+    flag: '🇺🇸',
+    circuit: 'Miami International Autodrome',
+    eventName: '2025 Miami Grand Prix',
+    timeZone: 'America/New_York',
+    offset: -4,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 5, day: 2, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 5, day: 2, hour: 16, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 5, day: 3, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 5, day: 3, hour: 16, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 5, day: 4, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'emilia-romagna-grand-prix',
+    round: 7,
+    country: 'Italy',
+    locality: 'Imola',
+    flag: '🇮🇹',
+    circuit: 'Autodromo Enzo e Dino Ferrari',
+    eventName: '2025 Emilia Romagna Grand Prix',
+    timeZone: 'Europe/Rome',
+    offset: 2,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 5, day: 16, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 5, day: 16, hour: 16, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 5, day: 17, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 5, day: 17, hour: 16, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 5, day: 18, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'monaco-grand-prix',
+    round: 8,
+    country: 'Monaco',
+    locality: 'Monte Carlo',
+    flag: '🇲🇨',
+    circuit: 'Circuit de Monaco',
+    eventName: '2025 Monaco Grand Prix',
+    timeZone: 'Europe/Monaco',
+    offset: 2,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 5, day: 23, hour: 13, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 5, day: 23, hour: 17, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 5, day: 24, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 5, day: 24, hour: 16, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 5, day: 25, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'spanish-grand-prix',
+    round: 9,
+    country: 'Spain',
+    locality: 'Barcelona',
+    flag: '🇪🇸',
+    circuit: 'Circuit de Barcelona-Catalunya',
+    eventName: '2025 Spanish Grand Prix',
+    timeZone: 'Europe/Madrid',
+    offset: 2,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 5, day: 30, hour: 13, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 5, day: 30, hour: 17, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 5, day: 31, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 5, day: 31, hour: 16, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 6, day: 1, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'canadian-grand-prix',
+    round: 10,
+    country: 'Canada',
+    locality: 'Montreal',
+    flag: '🇨🇦',
+    circuit: 'Circuit Gilles Villeneuve',
+    eventName: '2025 Canadian Grand Prix',
+    timeZone: 'America/Toronto',
+    offset: -4,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 6, day: 13, hour: 11, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 6, day: 13, hour: 15, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 6, day: 14, hour: 11, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 6, day: 14, hour: 15, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 6, day: 15, hour: 14, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'austrian-grand-prix',
+    round: 11,
+    country: 'Austria',
+    locality: 'Spielberg',
+    flag: '🇦🇹',
+    circuit: 'Red Bull Ring',
+    eventName: '2025 Austrian Grand Prix',
+    timeZone: 'Europe/Vienna',
+    offset: 2,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 6, day: 27, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 6, day: 27, hour: 16, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 6, day: 28, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 6, day: 28, hour: 16, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 6, day: 29, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'british-grand-prix',
+    round: 12,
+    country: 'United Kingdom',
+    locality: 'Silverstone',
+    flag: '🇬🇧',
+    circuit: 'Silverstone Circuit',
+    eventName: '2025 British Grand Prix',
+    timeZone: 'Europe/London',
+    offset: 1,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 7, day: 4, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 7, day: 4, hour: 16, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 7, day: 5, hour: 11, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 7, day: 5, hour: 15, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 7, day: 6, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'hungarian-grand-prix',
+    round: 13,
+    country: 'Hungary',
+    locality: 'Budapest',
+    flag: '🇭🇺',
+    circuit: 'Hungaroring',
+    eventName: '2025 Hungarian Grand Prix',
+    timeZone: 'Europe/Budapest',
+    offset: 2,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 7, day: 18, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 7, day: 18, hour: 16, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 7, day: 19, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 7, day: 19, hour: 16, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 7, day: 20, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'belgian-grand-prix',
+    round: 14,
+    country: 'Belgium',
+    locality: 'Spa-Francorchamps',
+    flag: '🇧🇪',
+    circuit: 'Circuit de Spa-Francorchamps',
+    eventName: '2025 Belgian Grand Prix',
+    timeZone: 'Europe/Brussels',
+    offset: 2,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 7, day: 25, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 7, day: 25, hour: 16, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 7, day: 26, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 7, day: 26, hour: 16, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 7, day: 27, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'dutch-grand-prix',
+    round: 15,
+    country: 'Netherlands',
+    locality: 'Zandvoort',
+    flag: '🇳🇱',
+    circuit: 'Circuit Zandvoort',
+    eventName: '2025 Dutch Grand Prix',
+    timeZone: 'Europe/Amsterdam',
+    offset: 2,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 8, day: 29, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 8, day: 29, hour: 16, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 8, day: 30, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 8, day: 30, hour: 16, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 8, day: 31, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'italian-grand-prix',
+    round: 16,
+    country: 'Italy',
+    locality: 'Monza',
+    flag: '🇮🇹',
+    circuit: 'Autodromo Nazionale Monza',
+    eventName: '2025 Italian Grand Prix',
+    timeZone: 'Europe/Rome',
+    offset: 2,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 9, day: 5, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 9, day: 5, hour: 16, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 9, day: 6, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 9, day: 6, hour: 16, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 9, day: 7, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'azerbaijan-grand-prix',
+    round: 17,
+    country: 'Azerbaijan',
+    locality: 'Baku',
+    flag: '🇦🇿',
+    circuit: 'Baku City Circuit',
+    eventName: '2025 Azerbaijan Grand Prix',
+    timeZone: 'Asia/Baku',
+    offset: 4,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 9, day: 19, hour: 13, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 9, day: 19, hour: 17, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 9, day: 20, hour: 13, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 9, day: 20, hour: 17, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 9, day: 21, hour: 15, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'singapore-grand-prix',
+    round: 18,
+    country: 'Singapore',
+    locality: 'Marina Bay',
+    flag: '🇸🇬',
+    circuit: 'Marina Bay Street Circuit',
+    eventName: '2025 Singapore Grand Prix',
+    timeZone: 'Asia/Singapore',
+    offset: 8,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 10, day: 3, hour: 17, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 10, day: 3, hour: 20, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 10, day: 4, hour: 17, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 10, day: 4, hour: 21, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 10, day: 5, hour: 20, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'united-states-grand-prix',
+    round: 19,
+    country: 'United States',
+    locality: 'Austin',
+    flag: '🇺🇸',
+    circuit: 'Circuit of The Americas',
+    eventName: '2025 United States Grand Prix',
+    timeZone: 'America/Chicago',
+    offset: -5,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 10, day: 17, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 10, day: 17, hour: 16, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 10, day: 18, hour: 12, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 10, day: 18, hour: 16, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 10, day: 19, hour: 14, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'mexico-city-grand-prix',
+    round: 20,
+    country: 'Mexico',
+    locality: 'Mexico City',
+    flag: '🇲🇽',
+    circuit: 'Autódromo Hermanos Rodríguez',
+    eventName: '2025 Mexico City Grand Prix',
+    timeZone: 'America/Mexico_City',
+    offset: -5,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 10, day: 24, hour: 11, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 10, day: 24, hour: 15, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 10, day: 25, hour: 11, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 10, day: 25, hour: 15, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 10, day: 26, hour: 14, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'saopaulo-grand-prix',
+    round: 21,
+    country: 'Brazil',
+    locality: 'São Paulo',
+    flag: '🇧🇷',
+    circuit: 'Autódromo José Carlos Pace',
+    eventName: '2025 São Paulo Grand Prix',
+    timeZone: 'America/Sao_Paulo',
+    offset: -3,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 11, day: 7, hour: 11, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 11, day: 7, hour: 15, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 11, day: 8, hour: 11, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 11, day: 8, hour: 15, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 11, day: 9, hour: 14, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'las-vegas-grand-prix',
+    round: 22,
+    country: 'United States',
+    locality: 'Las Vegas',
+    flag: '🇺🇸',
+    circuit: 'Las Vegas Strip Circuit',
+    eventName: '2025 Las Vegas Grand Prix',
+    timeZone: 'America/Los_Angeles',
+    offset: -7,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 11, day: 20, hour: 20, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 11, day: 21, hour: 0, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 11, day: 21, hour: 20, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 11, day: 22, hour: 0, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 11, day: 22, hour: 22, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'qatar-grand-prix',
+    round: 23,
+    country: 'Qatar',
+    locality: 'Lusail',
+    flag: '🇶🇦',
+    circuit: 'Lusail International Circuit',
+    eventName: '2025 Qatar Grand Prix',
+    timeZone: 'Asia/Qatar',
+    offset: 3,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 11, day: 28, hour: 16, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 11, day: 28, hour: 20, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 11, day: 29, hour: 17, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 11, day: 29, hour: 20, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 11, day: 30, hour: 20, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+  createEvent({
+    slug: 'abu-dhabi-grand-prix',
+    round: 24,
+    country: 'United Arab Emirates',
+    locality: 'Abu Dhabi',
+    flag: '🇦🇪',
+    circuit: 'Yas Marina Circuit',
+    eventName: '2025 Abu Dhabi Grand Prix',
+    timeZone: 'Asia/Dubai',
+    offset: 4,
+    sessions: [
+      {
+        type: 'practice1',
+        label: '프랙티스 1',
+        localTime: { year: 2025, month: 12, day: 5, hour: 14, minute: 30 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice2',
+        label: '프랙티스 2',
+        localTime: { year: 2025, month: 12, day: 5, hour: 18, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'practice3',
+        label: '프랙티스 3',
+        localTime: { year: 2025, month: 12, day: 6, hour: 15, minute: 0 },
+        durationMinutes: 60,
+      },
+      {
+        type: 'qualifying',
+        label: '예선',
+        localTime: { year: 2025, month: 12, day: 6, hour: 18, minute: 0 },
+        durationMinutes: 90,
+      },
+      {
+        type: 'race',
+        label: '레이스',
+        localTime: { year: 2025, month: 12, day: 7, hour: 17, minute: 0 },
+        durationMinutes: 120,
+      },
+    ],
+  }),
+];
+
+export const findCalanderEvent = (slug: string) =>
+  calanderEvents.find((event) => event.slug === slug);

--- a/src/domain/calander/data/trackMap.ts
+++ b/src/domain/calander/data/trackMap.ts
@@ -1,0 +1,432 @@
+export interface TrackInfo {
+  slug:
+    | 'australian-grand-prix'
+    | 'chinese-grand-prix'
+    | 'japanese-grand-prix'
+    | 'bahrain-grand-prix'
+    | 'saudi-arabian-grand-prix'
+    | 'miami-grand-prix'
+    | 'emilia-romagna-grand-prix'
+    | 'monaco-grand-prix'
+    | 'spanish-grand-prix'
+    | 'canadian-grand-prix'
+    | 'austrian-grand-prix'
+    | 'british-grand-prix'
+    | 'hungarian-grand-prix'
+    | 'belgian-grand-prix'
+    | 'dutch-grand-prix'
+    | 'italian-grand-prix'
+    | 'azerbaijan-grand-prix'
+    | 'singapore-grand-prix'
+    | 'united-states-grand-prix'
+    | 'mexico-city-grand-prix'
+    | 'saopaulo-grand-prix'
+    | 'las-vegas-grand-prix'
+    | 'qatar-grand-prix'
+    | 'abu-dhabi-grand-prix';
+  circuit: string;
+  location: string;
+  firstGrandPrix: number;
+  numberOfLaps: number;
+  circuitLengthKm: number;
+  raceDistanceKm: number;
+  cornerCount: number;
+  drsZones: number;
+  lapRecord: {
+    time: string;
+    driver: string;
+    year: number;
+  };
+  mapImage?: string;
+  alt?: string;
+}
+
+export const trackInfos: TrackInfo[] = [
+  {
+    slug: 'australian-grand-prix',
+    circuit: 'Albert Park Circuit',
+    location: 'Melbourne, Australia',
+    firstGrandPrix: 1996,
+    numberOfLaps: 58,
+    circuitLengthKm: 5.278,
+    raceDistanceKm: 306.124,
+    cornerCount: 14,
+    drsZones: 4,
+    lapRecord: {
+      time: '1:20.235',
+      driver: 'Carlos Sainz',
+      year: 2024,
+    },
+  },
+  {
+    slug: 'chinese-grand-prix',
+    circuit: 'Shanghai International Circuit',
+    location: 'Shanghai, China',
+    firstGrandPrix: 2004,
+    numberOfLaps: 56,
+    circuitLengthKm: 5.451,
+    raceDistanceKm: 305.066,
+    cornerCount: 16,
+    drsZones: 2,
+    lapRecord: {
+      time: '1:32.238',
+      driver: 'Michael Schumacher',
+      year: 2004,
+    },
+  },
+  {
+    slug: 'japanese-grand-prix',
+    circuit: 'Suzuka International Racing Course',
+    location: 'Suzuka, Japan',
+    firstGrandPrix: 1987,
+    numberOfLaps: 53,
+    circuitLengthKm: 5.807,
+    raceDistanceKm: 307.471,
+    cornerCount: 18,
+    drsZones: 1,
+    lapRecord: {
+      time: '1:30.983',
+      driver: 'Lewis Hamilton',
+      year: 2019,
+    },
+  },
+  {
+    slug: 'bahrain-grand-prix',
+    circuit: 'Bahrain International Circuit',
+    location: 'Sakhir, Bahrain',
+    firstGrandPrix: 2004,
+    numberOfLaps: 57,
+    circuitLengthKm: 5.412,
+    raceDistanceKm: 308.238,
+    cornerCount: 15,
+    drsZones: 3,
+    lapRecord: {
+      time: '1:31.447',
+      driver: 'Pedro de la Rosa',
+      year: 2005,
+    },
+  },
+  {
+    slug: 'saudi-arabian-grand-prix',
+    circuit: 'Jeddah Corniche Circuit',
+    location: 'Jeddah, Saudi Arabia',
+    firstGrandPrix: 2021,
+    numberOfLaps: 50,
+    circuitLengthKm: 6.174,
+    raceDistanceKm: 308.450,
+    cornerCount: 27,
+    drsZones: 3,
+    lapRecord: {
+      time: '1:30.734',
+      driver: 'Lewis Hamilton',
+      year: 2021,
+    },
+  },
+  {
+    slug: 'miami-grand-prix',
+    circuit: 'Miami International Autodrome',
+    location: 'Miami, United States',
+    firstGrandPrix: 2022,
+    numberOfLaps: 57,
+    circuitLengthKm: 5.412,
+    raceDistanceKm: 308.326,
+    cornerCount: 19,
+    drsZones: 3,
+    lapRecord: {
+      time: '1:29.708',
+      driver: 'Sergio Pérez',
+      year: 2023,
+    },
+  },
+  {
+    slug: 'emilia-romagna-grand-prix',
+    circuit: 'Autodromo Enzo e Dino Ferrari',
+    location: 'Imola, Italy',
+    firstGrandPrix: 1980,
+    numberOfLaps: 63,
+    circuitLengthKm: 4.909,
+    raceDistanceKm: 309.049,
+    cornerCount: 19,
+    drsZones: 1,
+    lapRecord: {
+      time: '1:15.484',
+      driver: 'Lewis Hamilton',
+      year: 2020,
+    },
+  },
+  {
+    slug: 'monaco-grand-prix',
+    circuit: 'Circuit de Monaco',
+    location: 'Monte Carlo, Monaco',
+    firstGrandPrix: 1950,
+    numberOfLaps: 78,
+    circuitLengthKm: 3.337,
+    raceDistanceKm: 260.286,
+    cornerCount: 19,
+    drsZones: 1,
+    lapRecord: {
+      time: '1:12.909',
+      driver: 'Lewis Hamilton',
+      year: 2021,
+    },
+  },
+  {
+    slug: 'spanish-grand-prix',
+    circuit: 'Circuit de Barcelona-Catalunya',
+    location: 'Barcelona, Spain',
+    firstGrandPrix: 1991,
+    numberOfLaps: 66,
+    circuitLengthKm: 4.657,
+    raceDistanceKm: 307.236,
+    cornerCount: 16,
+    drsZones: 2,
+    lapRecord: {
+      time: '1:16.330',
+      driver: 'Max Verstappen',
+      year: 2023,
+    },
+  },
+  {
+    slug: 'canadian-grand-prix',
+    circuit: 'Circuit Gilles Villeneuve',
+    location: 'Montreal, Canada',
+    firstGrandPrix: 1978,
+    numberOfLaps: 70,
+    circuitLengthKm: 4.361,
+    raceDistanceKm: 305.270,
+    cornerCount: 14,
+    drsZones: 3,
+    lapRecord: {
+      time: '1:13.078',
+      driver: 'Valtteri Bottas',
+      year: 2019,
+    },
+  },
+  {
+    slug: 'austrian-grand-prix',
+    circuit: 'Red Bull Ring',
+    location: 'Spielberg, Austria',
+    firstGrandPrix: 1970,
+    numberOfLaps: 71,
+    circuitLengthKm: 4.318,
+    raceDistanceKm: 306.452,
+    cornerCount: 10,
+    drsZones: 3,
+    lapRecord: {
+      time: '1:05.619',
+      driver: 'Carlos Sainz',
+      year: 2020,
+    },
+  },
+  {
+    slug: 'british-grand-prix',
+    circuit: 'Silverstone Circuit',
+    location: 'Silverstone, United Kingdom',
+    firstGrandPrix: 1950,
+    numberOfLaps: 52,
+    circuitLengthKm: 5.891,
+    raceDistanceKm: 306.198,
+    cornerCount: 18,
+    drsZones: 3,
+    lapRecord: {
+      time: '1:27.097',
+      driver: 'Max Verstappen',
+      year: 2020,
+    },
+  },
+  {
+    slug: 'hungarian-grand-prix',
+    circuit: 'Hungaroring',
+    location: 'Budapest, Hungary',
+    firstGrandPrix: 1986,
+    numberOfLaps: 70,
+    circuitLengthKm: 4.381,
+    raceDistanceKm: 306.630,
+    cornerCount: 14,
+    drsZones: 2,
+    lapRecord: {
+      time: '1:16.627',
+      driver: 'Lewis Hamilton',
+      year: 2020,
+    },
+  },
+  {
+    slug: 'belgian-grand-prix',
+    circuit: 'Circuit de Spa-Francorchamps',
+    location: 'Stavelot, Belgium',
+    firstGrandPrix: 1950,
+    numberOfLaps: 44,
+    circuitLengthKm: 7.004,
+    raceDistanceKm: 308.052,
+    cornerCount: 19,
+    drsZones: 2,
+    lapRecord: {
+      time: '1:46.286',
+      driver: 'Valtteri Bottas',
+      year: 2018,
+    },
+  },
+  {
+    slug: 'dutch-grand-prix',
+    circuit: 'Circuit Zandvoort',
+    location: 'Zandvoort, Netherlands',
+    firstGrandPrix: 1952,
+    numberOfLaps: 72,
+    circuitLengthKm: 4.259,
+    raceDistanceKm: 306.587,
+    cornerCount: 14,
+    drsZones: 2,
+    lapRecord: {
+      time: '1:11.097',
+      driver: 'Lewis Hamilton',
+      year: 2021,
+    },
+  },
+  {
+    slug: 'italian-grand-prix',
+    circuit: 'Autodromo Nazionale Monza',
+    location: 'Monza, Italy',
+    firstGrandPrix: 1950,
+    numberOfLaps: 53,
+    circuitLengthKm: 5.793,
+    raceDistanceKm: 306.720,
+    cornerCount: 11,
+    drsZones: 2,
+    lapRecord: {
+      time: '1:21.046',
+      driver: 'Rubens Barrichello',
+      year: 2004,
+    },
+  },
+  {
+    slug: 'azerbaijan-grand-prix',
+    circuit: 'Baku City Circuit',
+    location: 'Baku, Azerbaijan',
+    firstGrandPrix: 2016,
+    numberOfLaps: 51,
+    circuitLengthKm: 6.003,
+    raceDistanceKm: 306.049,
+    cornerCount: 20,
+    drsZones: 2,
+    lapRecord: {
+      time: '1:43.009',
+      driver: 'Charles Leclerc',
+      year: 2019,
+    },
+  },
+  {
+    slug: 'singapore-grand-prix',
+    circuit: 'Marina Bay Street Circuit',
+    location: 'Singapore, Singapore',
+    firstGrandPrix: 2008,
+    numberOfLaps: 62,
+    circuitLengthKm: 4.940,
+    raceDistanceKm: 306.143,
+    cornerCount: 19,
+    drsZones: 2,
+    lapRecord: {
+      time: '1:41.905',
+      driver: 'Kevin Magnussen',
+      year: 2018,
+    },
+  },
+  {
+    slug: 'united-states-grand-prix',
+    circuit: 'Circuit of The Americas',
+    location: 'Austin, United States',
+    firstGrandPrix: 2012,
+    numberOfLaps: 56,
+    circuitLengthKm: 5.513,
+    raceDistanceKm: 308.405,
+    cornerCount: 20,
+    drsZones: 3,
+    lapRecord: {
+      time: '1:36.169',
+      driver: 'Charles Leclerc',
+      year: 2019,
+    },
+  },
+  {
+    slug: 'mexico-city-grand-prix',
+    circuit: 'Autódromo Hermanos Rodríguez',
+    location: 'Mexico City, Mexico',
+    firstGrandPrix: 1963,
+    numberOfLaps: 71,
+    circuitLengthKm: 4.304,
+    raceDistanceKm: 305.354,
+    cornerCount: 16,
+    drsZones: 3,
+    lapRecord: {
+      time: '1:17.774',
+      driver: 'Valtteri Bottas',
+      year: 2021,
+    },
+  },
+  {
+    slug: 'saopaulo-grand-prix',
+    circuit: 'Autódromo José Carlos Pace',
+    location: 'São Paulo, Brazil',
+    firstGrandPrix: 1973,
+    numberOfLaps: 71,
+    circuitLengthKm: 4.309,
+    raceDistanceKm: 305.879,
+    cornerCount: 15,
+    drsZones: 2,
+    lapRecord: {
+      time: '1:10.540',
+      driver: 'Valtteri Bottas',
+      year: 2018,
+    },
+  },
+  {
+    slug: 'las-vegas-grand-prix',
+    circuit: 'Las Vegas Strip Circuit',
+    location: 'Las Vegas, United States',
+    firstGrandPrix: 2023,
+    numberOfLaps: 50,
+    circuitLengthKm: 6.201,
+    raceDistanceKm: 310.050,
+    cornerCount: 17,
+    drsZones: 2,
+    lapRecord: {
+      time: '1:35.490',
+      driver: 'Oscar Piastri',
+      year: 2023,
+    },
+  },
+  {
+    slug: 'qatar-grand-prix',
+    circuit: 'Lusail International Circuit',
+    location: 'Lusail, Qatar',
+    firstGrandPrix: 2021,
+    numberOfLaps: 57,
+    circuitLengthKm: 5.419,
+    raceDistanceKm: 308.611,
+    cornerCount: 16,
+    drsZones: 3,
+    lapRecord: {
+      time: '1:24.319',
+      driver: 'Lando Norris',
+      year: 2021,
+    },
+  },
+  {
+    slug: 'abu-dhabi-grand-prix',
+    circuit: 'Yas Marina Circuit',
+    location: 'Abu Dhabi, United Arab Emirates',
+    firstGrandPrix: 2009,
+    numberOfLaps: 58,
+    circuitLengthKm: 5.281,
+    raceDistanceKm: 306.183,
+    cornerCount: 16,
+    drsZones: 3,
+    lapRecord: {
+      time: '1:26.103',
+      driver: 'Max Verstappen',
+      year: 2021,
+    },
+  },
+];
+
+export const findTrackInfo = (slug: TrackInfo['slug']) =>
+  trackInfos.find((track) => track.slug === slug);

--- a/src/domain/calander/pages/calanderPage.css.ts
+++ b/src/domain/calander/pages/calanderPage.css.ts
@@ -1,0 +1,129 @@
+import { style } from '@vanilla-extract/css';
+
+export const page = style({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 32,
+  paddingTop: 96,
+  paddingBottom: 120,
+});
+
+export const hero = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: 32,
+  padding: '40px 48px',
+  borderRadius: 28,
+  background:
+    'linear-gradient(135deg, rgba(20, 30, 58, 0.92), rgba(57, 82, 182, 0.78))',
+  border: '1px solid rgba(82, 110, 210, 0.45)',
+  boxShadow: '0 32px 56px rgba(8, 12, 30, 0.65)',
+  color: '#e7edff',
+  selectors: {
+    ':root.light &': {
+      background:
+        'linear-gradient(135deg, rgba(218, 226, 255, 0.96), rgba(166, 182, 255, 0.86))',
+      border: '1px solid rgba(146, 160, 236, 0.48)',
+      boxShadow: '0 28px 58px rgba(122, 140, 230, 0.24)',
+      color: '#101835',
+    },
+  },
+});
+
+export const heroTitle = style({
+  margin: 0,
+  fontSize: 36,
+  fontWeight: 700,
+  letterSpacing: '-0.02em',
+});
+
+export const heroDescription = style({
+  margin: '12px 0 0',
+  fontSize: 15,
+  color: 'rgba(222, 230, 255, 0.86)',
+  maxWidth: 520,
+  lineHeight: 1.6,
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(44, 56, 108, 0.76)',
+    },
+  },
+});
+
+export const heroMeta = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  gap: 20,
+});
+
+export const heroMetaCard = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  padding: '18px 20px',
+  borderRadius: 18,
+  background: 'rgba(12, 18, 36, 0.48)',
+  border: '1px solid rgba(96, 118, 210, 0.35)',
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(222, 229, 255, 0.65)',
+      border: '1px solid rgba(160, 176, 240, 0.35)',
+    },
+  },
+});
+
+export const heroMetaLabel = style({
+  fontSize: 12,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  color: 'rgba(154, 178, 255, 0.78)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(64, 82, 150, 0.75)',
+    },
+  },
+});
+
+export const heroMetaValue = style({
+  fontSize: 18,
+  fontWeight: 600,
+  color: '#f6f8ff',
+  selectors: {
+    ':root.light &': {
+      color: '#1a2142',
+    },
+  },
+});
+
+export const heroMetaSub = style({
+  fontSize: 13,
+  color: 'rgba(200, 212, 250, 0.7)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(52, 66, 116, 0.68)',
+    },
+  },
+});
+
+export const layout = style({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(360px, 420px) minmax(0, 1fr)',
+  gap: 28,
+  alignItems: 'start',
+  '@media': {
+    'screen and (max-width: 1280px)': {
+      gridTemplateColumns: 'minmax(320px, 380px) minmax(0, 1fr)',
+    },
+    'screen and (max-width: 1024px)': {
+      gridTemplateColumns: '1fr',
+    },
+  },
+});
+
+export const detailColumn = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+});

--- a/src/domain/calander/pages/calanderPage.tsx
+++ b/src/domain/calander/pages/calanderPage.tsx
@@ -1,0 +1,175 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { MainContainer } from '@shared/layout/MainContainer.tsx';
+import { SideBar } from '@shared/ui/sidebar/SideBar.tsx';
+import { Header } from '@shared/ui/header/Header.tsx';
+import { Footer } from '@shared/ui/footer/Footer.tsx';
+import {
+  calanderEvents,
+  type CalanderEvent,
+} from '@domain/calander/data/calander.ts';
+import { CalanderList } from '@domain/calander/calanderList/calanderList.tsx';
+import { CalanderDetail } from '@domain/calander/calanderDetail/calanderDetail.tsx';
+import { TrackCard } from '@domain/calander/trackCard/trackCard.tsx';
+import { findTrackInfo } from '@domain/calander/data/trackMap.ts';
+import * as styles from './calanderPage.css.ts';
+import { useNavigate, useParams } from 'react-router-dom';
+
+interface CalanderPageProps {
+  appearance: 'light' | 'dark';
+  setAppearance: React.Dispatch<React.SetStateAction<'light' | 'dark'>>;
+}
+
+const getDefaultEvent = (): CalanderEvent | undefined => {
+  const now = Date.now();
+  const upcoming = calanderEvents.find((event) => {
+    const end = new Date(event.endDate).getTime();
+    return !Number.isNaN(end) && end >= now;
+  });
+
+  return upcoming ?? calanderEvents[0];
+};
+
+const formatDateTime = (iso: string | undefined) => {
+  if (!iso) {
+    return '';
+  }
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  const datePart = date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    timeZone: 'Asia/Seoul',
+  });
+  const timePart = date.toLocaleTimeString('ko-KR', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: 'Asia/Seoul',
+  });
+
+  return `${datePart} ${timePart}`;
+};
+
+export const CalanderPage = ({
+  appearance,
+  setAppearance,
+}: CalanderPageProps) => {
+  const navigate = useNavigate();
+  const { slug: paramSlug } = useParams<{ slug?: string }>();
+  const defaultEvent = useMemo(() => getDefaultEvent(), []);
+  const [selectedSlug, setSelectedSlug] = useState<string>(() => {
+    if (paramSlug) {
+      return paramSlug;
+    }
+    return defaultEvent?.slug ?? calanderEvents[0]?.slug ?? '';
+  });
+
+  useEffect(() => {
+    if (!defaultEvent) {
+      return;
+    }
+
+    if (!paramSlug) {
+      navigate(`/calendar/${defaultEvent.slug}`, { replace: true });
+      return;
+    }
+
+    const exists = calanderEvents.find((event) => event.slug === paramSlug);
+    if (exists) {
+      setSelectedSlug(exists.slug);
+    } else {
+      navigate(`/calendar/${defaultEvent.slug}`, { replace: true });
+    }
+  }, [defaultEvent, navigate, paramSlug]);
+
+  const selectedEvent = useMemo(() => {
+    const fallback = defaultEvent ?? calanderEvents[0];
+    return (
+      calanderEvents.find((event) => event.slug === selectedSlug) ?? fallback
+    );
+  }, [defaultEvent, selectedSlug]);
+
+  const nextEvent = useMemo(() => {
+    const now = Date.now();
+    return (
+      calanderEvents.find((event) => {
+        const start = new Date(event.startDate).getTime();
+        return !Number.isNaN(start) && start > now;
+      }) ?? calanderEvents[calanderEvents.length - 1]
+    );
+  }, []);
+
+  const track = useMemo(() => {
+    if (!selectedEvent) {
+      return undefined;
+    }
+    return findTrackInfo(selectedEvent.slug);
+  }, [selectedEvent]);
+
+  const handleSelect = (slug: string) => {
+    setSelectedSlug(slug);
+    navigate(`/calendar/${slug}`);
+  };
+
+  return (
+    <MainContainer
+      sidebar={<SideBar appearance={appearance} setAppearance={setAppearance} />}
+    >
+      <Header />
+      <div className={styles.page}>
+        <section className={styles.hero}>
+          <div>
+            <h1 className={styles.heroTitle}>GP 캘린더</h1>
+            <p className={styles.heroDescription}>
+              2025년 F1 시즌 24개 그랑프리의 주말 일정을 한눈에 확인하세요. 라운드를
+              선택하면 세션 세부 정보와 트랙 데이터를 자세히 볼 수 있습니다.
+            </p>
+          </div>
+
+          <div className={styles.heroMeta}>
+            <div className={styles.heroMetaCard}>
+              <span className={styles.heroMetaLabel}>다음 레이스</span>
+              <span className={styles.heroMetaValue}>{nextEvent?.eventName}</span>
+              <span className={styles.heroMetaSub}>
+                {formatDateTime(nextEvent?.raceStart)}
+                {nextEvent
+                  ? ` · ${nextEvent.country} / ${nextEvent.locality}`
+                  : ''}
+              </span>
+            </div>
+            <div className={styles.heroMetaCard}>
+              <span className={styles.heroMetaLabel}>선택된 라운드</span>
+              <span className={styles.heroMetaValue}>
+                Round {selectedEvent?.round ?? '-'}
+              </span>
+              <span className={styles.heroMetaSub}>
+                {selectedEvent?.eventName}
+                {selectedEvent
+                  ? ` · ${formatDateTime(selectedEvent.raceStart)}`
+                  : ''}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <div className={styles.layout}>
+          <CalanderList
+            events={calanderEvents}
+            selectedSlug={selectedSlug}
+            onSelect={handleSelect}
+          />
+
+          <div className={styles.detailColumn}>
+            <CalanderDetail event={selectedEvent ?? undefined} />
+            <TrackCard track={track} mapImage={track?.mapImage} />
+          </div>
+        </div>
+      </div>
+      <Footer />
+    </MainContainer>
+  );
+};

--- a/src/domain/calander/trackCard/trackCard.css.ts
+++ b/src/domain/calander/trackCard/trackCard.css.ts
@@ -1,0 +1,184 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+  padding: '32px',
+  borderRadius: 24,
+  background: 'rgba(9, 13, 24, 0.9)',
+  border: '1px solid rgba(66, 84, 138, 0.45)',
+  boxShadow: '0 24px 52px rgba(6, 10, 22, 0.55)',
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(245, 248, 255, 0.96)',
+      border: '1px solid rgba(132, 150, 212, 0.4)',
+      boxShadow: '0 24px 50px rgba(102, 124, 210, 0.2)',
+    },
+  },
+});
+
+export const header = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+});
+
+export const title = style({
+  margin: 0,
+  fontSize: 20,
+  fontWeight: 700,
+  color: '#f3f6ff',
+  selectors: {
+    ':root.light &': {
+      color: '#1a2140',
+    },
+  },
+});
+
+export const subtitle = style({
+  margin: 0,
+  fontSize: 14,
+  color: 'rgba(198, 210, 246, 0.72)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(46, 58, 102, 0.6)',
+    },
+  },
+});
+
+export const infoGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+  gap: 18,
+  '@media': {
+    'screen and (max-width: 1280px)': {
+      gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+    },
+    'screen and (max-width: 768px)': {
+      gridTemplateColumns: 'repeat(1, minmax(0, 1fr))',
+    },
+  },
+});
+
+export const infoItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  background: 'rgba(16, 22, 40, 0.78)',
+  borderRadius: 16,
+  padding: '14px 16px',
+  border: '1px solid rgba(76, 94, 150, 0.3)',
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(232, 238, 255, 0.65)',
+      border: '1px solid rgba(138, 156, 214, 0.32)',
+    },
+  },
+});
+
+export const infoLabel = style({
+  fontSize: 12,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  color: 'rgba(146, 164, 226, 0.72)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(60, 78, 132, 0.7)',
+    },
+  },
+});
+
+export const infoValue = style({
+  fontSize: 16,
+  fontWeight: 600,
+  color: '#f6f8ff',
+  selectors: {
+    ':root.light &': {
+      color: '#1a2140',
+    },
+  },
+});
+
+export const mapSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+});
+
+export const tabList = style({
+  display: 'flex',
+  gap: 12,
+});
+
+export const tabButton = style({
+  padding: '8px 16px',
+  borderRadius: 999,
+  border: '1px solid rgba(90, 112, 180, 0.6)',
+  background: 'rgba(28, 36, 64, 0.5)',
+  color: '#dfe6ff',
+  fontSize: 13,
+  fontWeight: 600,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  cursor: 'default',
+  selectors: {
+    ':root.light &': {
+      border: '1px solid rgba(120, 140, 206, 0.6)',
+      background: 'rgba(201, 210, 255, 0.35)',
+      color: '#1f2850',
+    },
+  },
+});
+
+export const mapContainer = style({
+  width: '100%',
+  minHeight: 260,
+  borderRadius: 20,
+  border: '1px dashed rgba(94, 114, 178, 0.45)',
+  background: 'rgba(14, 20, 36, 0.8)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  overflow: 'hidden',
+  selectors: {
+    ':root.light &': {
+      border: '1px dashed rgba(126, 146, 206, 0.5)',
+      background: 'rgba(228, 234, 255, 0.6)',
+    },
+  },
+});
+
+export const mapImage = style({
+  width: '100%',
+  height: '100%',
+  objectFit: 'contain',
+});
+
+export const mapPlaceholder = style({
+  fontSize: 14,
+  color: 'rgba(180, 196, 240, 0.7)',
+  textAlign: 'center',
+  padding: '24px',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(54, 66, 112, 0.7)',
+    },
+  },
+});
+
+export const recordHighlight = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+});
+
+export const recordDriver = style({
+  fontSize: 13,
+  color: 'rgba(178, 192, 238, 0.75)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(60, 76, 126, 0.66)',
+    },
+  },
+});

--- a/src/domain/calander/trackCard/trackCard.tsx
+++ b/src/domain/calander/trackCard/trackCard.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import type { TrackInfo } from '@domain/calander/data/trackMap.ts';
+import * as styles from './trackCard.css.ts';
+
+interface TrackCardProps {
+  track?: TrackInfo;
+  mapImage?: string;
+}
+
+const formatDistance = (value: number) => `${value.toFixed(3)} km`;
+
+export const TrackCard = ({ track, mapImage }: TrackCardProps) => {
+  if (!track) {
+    return (
+      <section className={styles.container} aria-label="트랙 정보 없음">
+        <div className={styles.header}>
+          <h2 className={styles.title}>트랙 정보</h2>
+          <p className={styles.subtitle}>
+            선택한 그랑프리에 해당하는 서킷 정보를 불러오는 중입니다.
+          </p>
+        </div>
+        <div className={styles.mapContainer}>
+          <p className={styles.mapPlaceholder}>트랙을 선택하면 상세 정보가 표시됩니다.</p>
+        </div>
+      </section>
+    );
+  }
+
+  const statItems: { label: string; value: React.ReactNode }[] = [
+    { label: '첫 그랑프리', value: track.firstGrandPrix },
+    { label: '랩 카운트', value: track.numberOfLaps },
+    { label: '서킷 길이', value: formatDistance(track.circuitLengthKm) },
+    { label: '레이스 거리', value: formatDistance(track.raceDistanceKm) },
+    { label: '코너 수', value: track.cornerCount },
+    { label: 'DRS 존', value: track.drsZones },
+    {
+      label: '랩 레코드',
+      value: (
+        <div className={styles.recordHighlight}>
+          <span className={styles.infoValue}>{track.lapRecord.time}</span>
+          <span className={styles.recordDriver}>
+            {track.lapRecord.driver} ({track.lapRecord.year})
+          </span>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <section className={styles.container} aria-labelledby={`${track.slug}-track-title`}>
+      <div className={styles.header}>
+        <h2 id={`${track.slug}-track-title`} className={styles.title}>
+          트랙 정보
+        </h2>
+        <p className={styles.subtitle}>
+          {track.circuit} · {track.location}
+        </p>
+      </div>
+
+      <div className={styles.infoGrid}>
+        {statItems.map((item) => (
+          <div key={item.label} className={styles.infoItem}>
+            <span className={styles.infoLabel}>{item.label}</span>
+            {typeof item.value === 'string' || typeof item.value === 'number' ? (
+              <span className={styles.infoValue}>{item.value}</span>
+            ) : (
+              item.value
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.mapSection}>
+        <div className={styles.tabList}>
+          <span className={styles.tabButton}>트랙맵</span>
+        </div>
+        <div className={styles.mapContainer}>
+          {mapImage ? (
+            <img
+              src={mapImage}
+              alt={track.alt ?? `${track.circuit} 트랙맵`}
+              className={styles.mapImage}
+            />
+          ) : (
+            <p className={styles.mapPlaceholder}>
+              트랙 레이아웃 이미지는 곧 업데이트될 예정입니다.
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/shared/ui/sidebar/SideBar.tsx
+++ b/src/shared/ui/sidebar/SideBar.tsx
@@ -20,6 +20,7 @@ import {
   ThemeIcon,
   SunIcon,
 } from '@shared/ui/sidebar/SideBarIcons.tsx';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 interface SideBarProps {
   appearance: 'light' | 'dark';
@@ -27,7 +28,7 @@ interface SideBarProps {
 }
 
 const primaryNavigation: MenuItem[] = [
-  { label: '레이스 캘린더', Icon: CalendarIcon },
+  { label: '레이스 캘린더', Icon: CalendarIcon, path: '/calendar' },
   { label: '최신 뉴스', Icon: NewsIcon },
   { label: 'FIA 문서', Icon: DocumentIcon },
   { label: '크리에이터 콘텐츠', Icon: CreatorIcon },
@@ -62,6 +63,8 @@ const controlItems: ControlItem[] = [
 ];
 
 export const SideBar = ({ appearance, setAppearance }: SideBarProps) => {
+  const navigate = useNavigate();
+  const location = useLocation();
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(
     () =>
       collapsibleNavigation.reduce<Record<string, boolean>>(
@@ -91,18 +94,35 @@ export const SideBar = ({ appearance, setAppearance }: SideBarProps) => {
         <nav className={styles.section} aria-label="주요 메뉴">
           <ul className={styles.menuList}>
             {primaryNavigation.map((item) => {
-              const IconComponent = item.Icon;
-              const isHighlight = (item as any).variant === 'highlight';
-              return (
-                <li key={item.label}>
-                  <button
-                    type="button"
-                    className={`${styles.menuButton} ${isHighlight ? styles.menuButtonHighlight : ''}`}
-                  >
-                    <span className={styles.iconWrapper}>
-                      <IconComponent className={styles.icon} />
-                    </span>
-                    <span className={styles.label}>{item.label}</span>
+          const IconComponent = item.Icon;
+          const isHighlight = (item as any).variant === 'highlight';
+          const isActive = item.path
+            ? location.pathname.startsWith(item.path)
+            : false;
+          const className = [
+            styles.menuButton,
+            isHighlight ? styles.menuButtonHighlight : '',
+            isActive ? styles.menuButtonActive : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+          const handleClick = () => {
+            if (item.path) {
+              navigate(item.path);
+            }
+          };
+          return (
+            <li key={item.label}>
+              <button
+                type="button"
+                className={className}
+                onClick={handleClick}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                <span className={styles.iconWrapper}>
+                  <IconComponent className={styles.icon} />
+                </span>
+                <span className={styles.label}>{item.label}</span>
                     {(item as any).tag ? (
                       <span className={styles.tag}>{(item as any).tag}</span>
                     ) : null}

--- a/src/shared/ui/sidebar/sidebarType.ts
+++ b/src/shared/ui/sidebar/sidebarType.ts
@@ -9,6 +9,7 @@ export type MenuItem = {
   Icon: (props: SvgIconProps) => JSX.Element;
   variant?: 'highlight';
   tag?: string;
+  path?: string;
 };
 
 export type CollapsibleNavItem = {

--- a/src/shared/ui/styles/sidebar/sidebar.css.ts
+++ b/src/shared/ui/styles/sidebar/sidebar.css.ts
@@ -78,6 +78,15 @@ export const menuButtonHighlight = style([
   },
 ]);
 
+export const menuButtonActive = style([
+  menuButton,
+  {
+    background: 'rgba(96, 118, 210, 0.24)',
+    color: '#ffffff',
+    boxShadow: '0 16px 32px rgba(52, 72, 168, 0.4)',
+  },
+]);
+
 export const menuButtonOpen = style([
   menuButton,
   {
@@ -182,6 +191,12 @@ globalStyle(`.light .${menuButtonHighlight}`, {
     'linear-gradient(135deg, rgba(143, 161, 245, 0.28), rgba(103, 133, 236, 0.18))',
   color: '#141836',
   boxShadow: '0 12px 28px rgba(120, 145, 226, 0.35)',
+});
+
+globalStyle(`.light .${menuButtonActive}`, {
+  background: 'rgba(154, 172, 245, 0.24)',
+  color: '#1b2350',
+  boxShadow: '0 16px 32px rgba(140, 160, 240, 0.28)',
 });
 
 globalStyle(`.light .${menuButtonHighlight}:hover`, {


### PR DESCRIPTION
## Summary
- add structured 2025 F1 calendar and companion track metadata for race weekend planning
- build calendar list, detail, and track components with vanilla-extract styling and status handling
- create the calendar page, wire routing, and activate the sidebar entry for the new experience

## Testing
- yarn lint
- yarn build *(fails: missing cached packages for TypeScript/Vite in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e373e829dc83319d16d08f0895204d