### PR TITLE
Add bracket wrapper around driver ranking cards

### DIFF
--- a/src/domain/championship/components/BracketWrapper.tsx
+++ b/src/domain/championship/components/BracketWrapper.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+import * as styles from '../styles/bracketWrapper.css.ts';
+
+interface BracketWrapperProps {
+  position: number;
+  children: ReactNode;
+}
+
+export const BracketWrapper = ({ position, children }: BracketWrapperProps) => {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.positionNumber}>{position}</div>
+      {children}
+    </div>
+  );
+};

--- a/src/domain/championship/components/DriverRankingShowcase.tsx
+++ b/src/domain/championship/components/DriverRankingShowcase.tsx
@@ -1,3 +1,4 @@
+import { BracketWrapper } from './BracketWrapper.tsx';
 import * as styles from '../styles/driverRanking.css.ts';
 import kimiAntonelli from '@domain/driver/img/2025mercedesandant01right.png';
 
@@ -273,43 +274,44 @@ export const DriverRankingShowcase = () => {
 
       <div className={styles.grid}>
         {sortedDrivers.map((driver, index) => (
-          <article
-            key={driver.id}
-            className={`${styles.card} ${styles.cardThemes[driver.teamId]}`}
-            aria-label={`${driver.name} 순위 카드`}
-          >
-            <div className={styles.cardBody}>
-              <div className={styles.driverHeader}>
-                <img
-                  className={styles.teamLogo}
-                  src={driver.teamLogoUrl}
-                  alt={`${driver.teamName} 로고`}
-                  loading="lazy"
-                />
-                <div className={styles.driverMeta}>
-                  <span className={styles.driverCode}>No.{index + 1}</span>
-                  <h3 className={styles.driverName}>{driver.name}</h3>
+          <BracketWrapper key={driver.id} position={index + 1}>
+            <article
+              className={`${styles.card} ${styles.cardThemes[driver.teamId]}`}
+              aria-label={`${driver.name} 순위 카드`}
+            >
+              <div className={styles.cardBody}>
+                <div className={styles.driverHeader}>
+                  <img
+                    className={styles.teamLogo}
+                    src={driver.teamLogoUrl}
+                    alt={`${driver.teamName} 로고`}
+                    loading="lazy"
+                  />
+                  <div className={styles.driverMeta}>
+                    <span className={styles.driverCode}>No.{index + 1}</span>
+                    <h3 className={styles.driverName}>{driver.name}</h3>
+                  </div>
+                </div>
+
+                <div className={styles.infoRow}>
+                  <span className={styles.teamBadge}>{driver.teamName}</span>
+                  <div className={styles.points}>
+                    <span className={styles.pointsLabel}>드라이버 포인트</span>
+                    <span className={styles.pointsValue}>
+                      {driver.points.toLocaleString()}
+                    </span>
+                  </div>
                 </div>
               </div>
 
-              <div className={styles.infoRow}>
-                <span className={styles.teamBadge}>{driver.teamName}</span>
-                <div className={styles.points}>
-                  <span className={styles.pointsLabel}>드라이버 포인트</span>
-                  <span className={styles.pointsValue}>
-                    {driver.points.toLocaleString()}
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            <img
-              className={styles.driverImage}
-              src={driver.imageUrl}
-              alt={`${driver.name} 드라이버 이미지`}
-              loading="lazy"
-            />
-          </article>
+              <img
+                className={styles.driverImage}
+                src={driver.imageUrl}
+                alt={`${driver.name} 드라이버 이미지`}
+                loading="lazy"
+              />
+            </article>
+          </BracketWrapper>
         ))}
       </div>
     </section>

--- a/src/domain/championship/styles/bracketWrapper.css.ts
+++ b/src/domain/championship/styles/bracketWrapper.css.ts
@@ -1,0 +1,26 @@
+import { style } from '@vanilla-extract/css';
+import { colorVars } from '@shared/styles/color.css.ts';
+
+export const wrapper = style({
+  borderTop: '2px solid currentColor',
+  borderLeft: '2px solid currentColor',
+  borderRight: '2px solid currentColor',
+  padding: '20px',
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  color: colorVars.text.heading,
+});
+
+export const positionNumber = style({
+  position: 'absolute',
+  top: '-16px',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  fontWeight: 800,
+  fontSize: '16px',
+  background: colorVars.surface.panel,
+  padding: '4px 10px',
+  borderRadius: '999px',
+  boxShadow: colorVars.effect.elevation,
+});


### PR DESCRIPTION
## Summary
- add a reusable bracket wrapper component to frame driver cards with the required U-shaped border
- create bracket styling to show the border and centered position number above each card
- wrap each driver ranking card with the new bracket so all positions display the frame

## Testing
- yarn lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929a3982c2083319657351dea8fa017)