### PR TITLE
Add U-shaped brackets to starting grid cards

### DIFF
--- a/src/domain/grid/components/BracketWrapper.tsx
+++ b/src/domain/grid/components/BracketWrapper.tsx
@@ -9,8 +9,8 @@ interface BracketWrapperProps {
 export const BracketWrapper = ({ position, children }: BracketWrapperProps) => {
   return (
     <div className={styles.container}>
+      <span className={styles.positionLabel}>{position}</span>
       <div className={styles.frame}>
-        <span className={styles.positionLabel}>{position}</span>
         <div className={styles.frameInner}>{children}</div>
       </div>
     </div>

--- a/src/domain/grid/styles/bracketWrapper.css.ts
+++ b/src/domain/grid/styles/bracketWrapper.css.ts
@@ -3,36 +3,52 @@ import { vars } from '@shared/styles/token.css.ts';
 
 export const container = style({
   display: 'flex',
+  position: 'relative',
   width: '100%',
+  flexDirection: 'column',
+  alignItems: 'center',
   justifyContent: 'center',
+  gap: '12px',
+  paddingInline: '12px',
 });
 
 export const frame = style({
   position: 'relative',
-  width: 'min(100%, 440px)',
-  padding: '36px 32px 28px',
-  borderTop: '2px solid currentColor',
-  borderLeft: '2px solid currentColor',
-  borderRight: '2px solid currentColor',
+  width: 'min(100%, 520px)',
+  padding: '52px 44px 48px',
   color: vars.color.gridCardDivider,
   display: 'flex',
   justifyContent: 'center',
+  alignItems: 'center',
+  borderRadius: '22px 22px 0 0',
+  selectors: {
+    '&::before': {
+      content: '',
+      position: 'absolute',
+      inset: 0,
+      borderTop: '3px solid currentColor',
+      borderLeft: '3px solid currentColor',
+      borderRight: '3px solid currentColor',
+      borderBottom: 'none',
+      borderRadius: '22px 22px 0 0',
+      pointerEvents: 'none',
+    },
+  },
 });
 
 export const positionLabel = style({
-  position: 'absolute',
-  top: '-18px',
-  left: '50%',
-  transform: 'translateX(-50%)',
+  position: 'relative',
   fontSize: '20px',
   fontWeight: 800,
   fontStyle: 'italic',
   letterSpacing: '0.08em',
-  padding: '6px 12px',
+  padding: '8px 14px',
   borderRadius: '999px',
   background: vars.color.gridCardBg,
   color: vars.color.gridCardAccent,
   boxShadow: '0 10px 24px rgba(0, 0, 0, 0.28)',
+  transform: 'translateY(8px)',
+  zIndex: 1,
 });
 
 export const frameInner = style({
@@ -40,5 +56,5 @@ export const frameInner = style({
   maxWidth: '360px',
   display: 'flex',
   justifyContent: 'center',
-  paddingInline: '4px',
+  padding: '10px 8px',
 });


### PR DESCRIPTION
## Summary
- wrap starting grid cards with a dedicated U-shaped bracket frame
- reposition grid position labels above each bracket for clearer alignment
- size the bracket larger than the card with padding so the open-bottom outline is visible in light and dark themes

## Testing
- yarn lint *(fails: missing dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929aaf3806c8331bd6c0880210885cc)