### PR TITLE
Add weather page with mock forecasts and sidebar link

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -19,6 +19,7 @@ import { ConstructorStandingsPage } from '@domain/championship/pages/Constructor
 import { DriverRankingPage } from '@domain/championship/pages/DriverRankingPage.tsx';
 import { NewsListPage } from '@domain/news/NewsListPage.tsx';
 import { NewsDetailPage } from '@domain/news/NewsDetailPage.tsx';
+import { WeatherPage } from '@domain/weather/pages/WeatherPage.tsx';
 
 interface RouterProps {
   appearance: 'light' | 'dark';
@@ -90,6 +91,15 @@ export const Router = ({ appearance, setAppearance }: RouterProps) => {
           path="/calendar/:slug"
           element={
             <CalenderPage
+              appearance={appearance}
+              setAppearance={setAppearance}
+            />
+          }
+        />
+        <Route
+          path="/weather"
+          element={
+            <WeatherPage
               appearance={appearance}
               setAppearance={setAppearance}
             />

--- a/src/domain/weather/components/WeatherHero.tsx
+++ b/src/domain/weather/components/WeatherHero.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { WeatherReport } from '@domain/weather/data/weatherMock.ts';
+import * as styles from '@domain/weather/styles/weatherPage.css.ts';
+
+const formatDateTime = (iso: string) => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return '-';
+  }
+
+  return date.toLocaleString('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: 'Asia/Seoul',
+  });
+};
+
+interface WeatherHeroProps {
+  nextEvent: WeatherReport;
+}
+
+export const WeatherHero = ({ nextEvent }: WeatherHeroProps) => {
+  return (
+    <section className={styles.hero}>
+      <div className={styles.heroText}>
+        <p className={styles.heroBadge}>다음 예정된 경기</p>
+        <h1 className={styles.heroTitle}>F1 트랙 사이드 날씨 센터</h1>
+        <p className={styles.heroSubtitle}>
+          openf1 weather API 응답 스키마를 바탕으로 만든 목업 데이터입니다.
+          주말 일정에 맞춰 기온, 노면 상태, 강수 확률을 한눈에 확인하세요.
+        </p>
+
+        <div className={styles.heroMeta}>
+          <div className={styles.metaCard}>
+            <span className={styles.metaLabel}>라운드</span>
+            <span className={styles.metaValue}>Round {nextEvent.round}</span>
+            <span className={styles.metaSub}>{nextEvent.eventName}</span>
+          </div>
+          <div className={styles.metaCard}>
+            <span className={styles.metaLabel}>시간</span>
+            <span className={styles.metaValue}>{formatDateTime(nextEvent.raceDate)}</span>
+            <span className={styles.metaSub}>
+              {nextEvent.country} · {nextEvent.locality}
+            </span>
+          </div>
+          <div className={styles.metaCard}>
+            <span className={styles.metaLabel}>상태</span>
+            <span className={styles.metaValue}>{nextEvent.summary}</span>
+            <span className={styles.metaSub}>{nextEvent.status}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.heroCard}>
+        <div className={styles.heroHighlight}>{nextEvent.condition ?? nextEvent.summary}</div>
+        <p className={styles.heroStatus}>{nextEvent.status}</p>
+        <div className={styles.heroMeta} style={{ marginTop: 0 }}>
+          <div className={styles.metaCard}>
+            <span className={styles.metaLabel}>기온 / 노면</span>
+            <span className={styles.metaValue}>
+              {nextEvent.airTemp}℃ / {nextEvent.trackTemp}℃
+            </span>
+            <span className={styles.metaSub}>체감 {nextEvent.summary}</span>
+          </div>
+          <div className={styles.metaCard}>
+            <span className={styles.metaLabel}>강수 확률</span>
+            <span className={styles.metaValue}>{nextEvent.rainChance}%</span>
+            <span className={styles.metaSub}>압력 {nextEvent.pressure} hPa</span>
+          </div>
+          <div className={styles.metaCard}>
+            <span className={styles.metaLabel}>풍향 · 풍속</span>
+            <span className={styles.metaValue}>
+              {nextEvent.windDirection} / {nextEvent.windSpeed} km/h
+            </span>
+            <span className={styles.metaSub}>타이어 전략 참고용</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/domain/weather/data/weatherMock.ts
+++ b/src/domain/weather/data/weatherMock.ts
@@ -1,0 +1,226 @@
+import {
+  CalenderEvents,
+  type CalenderEvent,
+} from '@domain/calender/data/calender.ts';
+
+export type WeatherSession = {
+  label: string;
+  time: string;
+  airTemp: number;
+  trackTemp: number;
+  humidity: number;
+  windSpeed: number;
+  rainChance: number;
+  condition: string;
+};
+
+export type WeatherReport = {
+  slug: string;
+  round: number;
+  eventName: string;
+  country: string;
+  locality: string;
+  raceDate: string;
+  isUpcoming: boolean;
+  summary: string;
+  status: string;
+  condition: string;
+  airTemp: number;
+  trackTemp: number;
+  humidity: number;
+  rainChance: number;
+  pressure: number;
+  windSpeed: number;
+  windDirection: string;
+  sessions: WeatherSession[];
+};
+
+type WeatherTemplate = {
+  condition: string;
+  status: string;
+  airTemp: number;
+  trackTemp: number;
+  humidity: number;
+  rainChance: number;
+  pressure: number;
+  windSpeed: number;
+  windDirection: string;
+};
+
+const weatherTemplates: Record<string, WeatherTemplate> = {
+  'australian-grand-prix': {
+    condition: '맑음',
+    status: '건조한 노면, 고온',
+    airTemp: 24,
+    trackTemp: 38,
+    humidity: 46,
+    rainChance: 8,
+    pressure: 1014,
+    windSpeed: 18,
+    windDirection: '남서풍',
+  },
+  'chinese-grand-prix': {
+    condition: '부분적으로 흐림',
+    status: '약한 안개와 구름',
+    airTemp: 19,
+    trackTemp: 32,
+    humidity: 58,
+    rainChance: 22,
+    pressure: 1011,
+    windSpeed: 14,
+    windDirection: '북동풍',
+  },
+  'japanese-grand-prix': {
+    condition: '흐림',
+    status: '짙은 구름과 서늘한 공기',
+    airTemp: 17,
+    trackTemp: 26,
+    humidity: 64,
+    rainChance: 34,
+    pressure: 1008,
+    windSpeed: 20,
+    windDirection: '북서풍',
+  },
+  'bahrain-grand-prix': {
+    condition: '쾌청',
+    status: '건조하고 바람 약함',
+    airTemp: 27,
+    trackTemp: 42,
+    humidity: 32,
+    rainChance: 2,
+    pressure: 1010,
+    windSpeed: 12,
+    windDirection: '북풍',
+  },
+  'italian-grand-prix': {
+    condition: '맑음',
+    status: '안정적인 고기압',
+    airTemp: 22,
+    trackTemp: 37,
+    humidity: 48,
+    rainChance: 15,
+    pressure: 1016,
+    windSpeed: 10,
+    windDirection: '동풍',
+  },
+  'british-grand-prix': {
+    condition: '소나기',
+    status: '구름 많고 변덕스러운 바람',
+    airTemp: 16,
+    trackTemp: 24,
+    humidity: 71,
+    rainChance: 52,
+    pressure: 1005,
+    windSpeed: 22,
+    windDirection: '서풍',
+  },
+  'qatar-grand-prix': {
+    condition: '짙은 안개',
+    status: '미세먼지와 건조',
+    airTemp: 29,
+    trackTemp: 44,
+    humidity: 28,
+    rainChance: 4,
+    pressure: 1007,
+    windSpeed: 16,
+    windDirection: '북동풍',
+  },
+};
+
+const defaultTemplate: WeatherTemplate = {
+  condition: '맑음',
+  status: '안정적인 컨디션',
+  airTemp: 23,
+  trackTemp: 35,
+  humidity: 52,
+  rainChance: 18,
+  pressure: 1013,
+  windSpeed: 13,
+  windDirection: '남동풍',
+};
+
+const deriveSessionWeather = (
+  sessionType: string,
+  base: WeatherTemplate
+): WeatherSession => {
+  const modifiers: Record<string, number> = {
+    practice1: -1,
+    practice2: 0,
+    practice3: -2,
+    qualifying: 1,
+    sprintShootout: 1,
+    sprint: 0,
+    race: 1,
+  };
+
+  const delta = modifiers[sessionType] ?? 0;
+  const windVariation = sessionType === 'race' ? 3 : 1;
+  const humidityAdjustment = sessionType === 'race' ? 2 : 0;
+
+  return {
+    label: sessionType,
+    time: '',
+    airTemp: base.airTemp + delta,
+    trackTemp: base.trackTemp + delta * 1.5,
+    humidity: Math.min(100, base.humidity + humidityAdjustment),
+    windSpeed: base.windSpeed + windVariation,
+    rainChance: Math.min(100, Math.max(0, base.rainChance + delta * 2)),
+    condition: base.condition,
+  };
+};
+
+const normalizeSessionLabel = (label: string) => {
+  const map: Record<string, string> = {
+    practice1: '프랙티스 1',
+    practice2: '프랙티스 2',
+    practice3: '프랙티스 3',
+    sprintShootout: '스프린트 슈트아웃',
+    sprint: '스프린트',
+    qualifying: '퀄리파잉',
+    race: '레이스',
+  };
+
+  return map[label] ?? label;
+};
+
+const createWeatherReport = (event: CalenderEvent): WeatherReport => {
+  const base = weatherTemplates[event.slug] ?? defaultTemplate;
+  const raceDate = event.raceStart;
+  const now = Date.now();
+  const raceTimestamp = new Date(raceDate).getTime();
+  const isUpcoming = !Number.isNaN(raceTimestamp) && raceTimestamp > now;
+
+  const sessions: WeatherSession[] = event.sessions.map((session) => {
+    const weather = deriveSessionWeather(session.type, base);
+    return {
+      ...weather,
+      label: normalizeSessionLabel(session.type),
+      time: session.start,
+    };
+  });
+
+  return {
+    slug: event.slug,
+    round: event.round,
+    eventName: event.eventName,
+    country: event.country,
+    locality: event.locality,
+    raceDate,
+    isUpcoming,
+    summary: `${base.condition} · 체감 ${base.airTemp}℃`,
+    status: base.status,
+    condition: base.condition,
+    airTemp: base.airTemp,
+    trackTemp: base.trackTemp,
+    humidity: base.humidity,
+    rainChance: base.rainChance,
+    pressure: base.pressure,
+    windSpeed: base.windSpeed,
+    windDirection: base.windDirection,
+    sessions,
+  };
+};
+
+export const WeatherReports: WeatherReport[] = CalenderEvents.map((event) =>
+  createWeatherReport(event)
+);

--- a/src/domain/weather/pages/WeatherPage.tsx
+++ b/src/domain/weather/pages/WeatherPage.tsx
@@ -1,0 +1,266 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { MainContainer } from '@shared/layout/MainContainer.tsx';
+import { SideBar } from '@shared/ui/sidebar/SideBar.tsx';
+import { Header } from '@shared/ui/header/Header.tsx';
+import { Footer } from '@shared/ui/footer/Footer.tsx';
+import {
+  WeatherReports,
+  type WeatherReport,
+} from '@domain/weather/data/weatherMock.ts';
+import * as styles from '@domain/weather/styles/weatherPage.css.ts';
+import { WeatherHero } from '@domain/weather/components/WeatherHero.tsx';
+
+interface WeatherPageProps {
+  appearance: 'light' | 'dark';
+  setAppearance: React.Dispatch<React.SetStateAction<'light' | 'dark'>>;
+}
+
+const formatDate = (iso: string) => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return '-';
+  }
+
+  return date.toLocaleDateString('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+    timeZone: 'Asia/Seoul',
+  });
+};
+
+const formatTime = (iso: string) => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return '-';
+  }
+
+  return date.toLocaleTimeString('ko-KR', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: 'Asia/Seoul',
+  });
+};
+
+const findNextEvent = (reports: WeatherReport[]) => {
+  const now = Date.now();
+  return (
+    reports.find((report) => {
+      const race = new Date(report.raceDate).getTime();
+      return !Number.isNaN(race) && race > now;
+    }) ?? reports[reports.length - 1]
+  );
+};
+
+export const WeatherPage = ({ appearance, setAppearance }: WeatherPageProps) => {
+  const sortedReports = useMemo(
+    () => [...WeatherReports].sort((a, b) => a.round - b.round),
+    []
+  );
+  const nextEvent = useMemo(
+    () => findNextEvent(sortedReports),
+    [sortedReports]
+  );
+
+  const [selectedSlug, setSelectedSlug] = useState<string>(
+    nextEvent?.slug ?? sortedReports[0]?.slug ?? ''
+  );
+
+  const selectedEvent = useMemo(
+    () => sortedReports.find((report) => report.slug === selectedSlug),
+    [sortedReports, selectedSlug]
+  );
+
+  const pastReports = useMemo(() => {
+    const now = Date.now();
+    return sortedReports
+      .filter((report) => new Date(report.raceDate).getTime() <= now)
+      .sort((a, b) => b.round - a.round);
+  }, [sortedReports]);
+
+  const historyOptions = pastReports.length > 0 ? pastReports : sortedReports;
+
+  const [historySlug, setHistorySlug] = useState<string>(
+    pastReports[0]?.slug ?? sortedReports[0]?.slug ?? ''
+  );
+
+  const historyEvent = useMemo(
+    () => sortedReports.find((report) => report.slug === historySlug),
+    [sortedReports, historySlug]
+  );
+
+  useEffect(() => {
+    if (!historyOptions.find((report) => report.slug === historySlug)) {
+      const fallback = historyOptions[0];
+      if (fallback) {
+        setHistorySlug(fallback.slug);
+      }
+    }
+  }, [historyOptions, historySlug]);
+
+  return (
+    <MainContainer
+      sidebar={<SideBar appearance={appearance} setAppearance={setAppearance} />}
+    >
+      <Header />
+      <div className={styles.page}>
+        {nextEvent ? <WeatherHero nextEvent={nextEvent} /> : null}
+
+        <div className={styles.layout}>
+          <aside className={styles.sectionCard}>
+            <div>
+              <h2 className={styles.sectionTitle}>경기별 날씨</h2>
+              <p className={styles.description}>
+                캘린더 일정과 동일하게 라운드 순으로 정렬한 날씨 목록입니다.
+                원하는 경기를 선택하면 세션별 기온과 노면 컨디션을 확인할 수
+                있습니다.
+              </p>
+            </div>
+            <div className={styles.eventList}>
+              {sortedReports.map((report) => {
+                const isActive = report.slug === selectedSlug;
+                const badgeText = report.isUpcoming ? '예정' : '완료';
+
+                return (
+                  <button
+                    key={report.slug}
+                    type="button"
+                    className={`${styles.eventButton} ${
+                      isActive ? styles.activeEvent : ''
+                    }`}
+                    onClick={() => setSelectedSlug(report.slug)}
+                  >
+                    <span className={styles.eventLabel}>
+                      <span className={styles.eventName}>{report.eventName}</span>
+                      <span className={styles.eventMeta}>
+                        Round {report.round} · {formatDate(report.raceDate)}
+                      </span>
+                    </span>
+                    <span className={styles.badge}>{badgeText}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </aside>
+
+          <section className={styles.detailCard}>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <div>
+                <h2 className={styles.sectionTitle}>
+                  {selectedEvent?.eventName ?? '날씨 정보'}
+                </h2>
+                <p className={styles.description}>
+                  {selectedEvent
+                    ? `${selectedEvent.country} · ${selectedEvent.locality} | ${formatDate(selectedEvent.raceDate)}`
+                    : '경기를 선택해 세션별 데이터를 확인하세요.'}
+                </p>
+              </div>
+              <span className={styles.badge}>
+                {selectedEvent?.isUpcoming ? '예정' : '완료'}
+              </span>
+            </div>
+
+            {selectedEvent ? (
+              <>
+                <div className={styles.statsGrid}>
+                  <div className={styles.stat}>
+                    <span className={styles.statLabel}>기온 / 노면</span>
+                    <div className={styles.statValue}>
+                      {selectedEvent.airTemp}℃ / {selectedEvent.trackTemp}℃
+                    </div>
+                  </div>
+                  <div className={styles.stat}>
+                    <span className={styles.statLabel}>습도</span>
+                    <div className={styles.statValue}>{selectedEvent.humidity}%</div>
+                  </div>
+                  <div className={styles.stat}>
+                    <span className={styles.statLabel}>강수 확률</span>
+                    <div className={styles.statValue}>{selectedEvent.rainChance}%</div>
+                  </div>
+                  <div className={styles.stat}>
+                    <span className={styles.statLabel}>기압</span>
+                    <div className={styles.statValue}>{selectedEvent.pressure} hPa</div>
+                  </div>
+                  <div className={styles.stat}>
+                    <span className={styles.statLabel}>풍향 · 풍속</span>
+                    <div className={styles.statValue}>
+                      {selectedEvent.windDirection} / {selectedEvent.windSpeed} km/h
+                    </div>
+                  </div>
+                </div>
+
+                <div className={styles.sessionList}>
+                  {selectedEvent.sessions.map((session) => (
+                    <div key={session.label + session.time} className={styles.sessionRow}>
+                      <div>
+                        <div className={styles.sessionTitle}>{session.label}</div>
+                        <div className={styles.eventMeta}>{formatTime(session.time)}</div>
+                      </div>
+                      <div className={styles.sessionMeta}>
+                        <span className={styles.chip}>{session.condition}</span>
+                        <span className={styles.chip}>
+                          {session.airTemp}℃ / {session.trackTemp}℃
+                        </span>
+                        <span className={styles.chip}>습도 {session.humidity}%</span>
+                        <span className={styles.chip}>강수 {session.rainChance}%</span>
+                        <span className={styles.chip}>풍속 {session.windSpeed} km/h</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
+            ) : null}
+          </section>
+        </div>
+
+        <section className={styles.sectionCard}>
+          <div>
+            <h2 className={styles.sectionTitle}>지난 경기 날씨 기록</h2>
+            <p className={styles.description}>
+              원하는 라운드를 선택하면 레이스 당일 컨디션을 요약해서 보여줍니다.
+              실제 API 대신 캘린더 일정과 장소를 기준으로 생성한 목업입니다.
+            </p>
+          </div>
+
+          <div className={styles.historyControl}>
+            <select
+              className={styles.select}
+              value={historySlug}
+              onChange={(event) => setHistorySlug(event.target.value)}
+            >
+              {historyOptions.map((report) => (
+                <option key={report.slug} value={report.slug}>
+                  Round {report.round} · {report.eventName}
+                </option>
+              ))}
+            </select>
+
+            {historyEvent ? (
+              <div className={styles.historyCard}>
+                <h3 className={styles.historyTitle}>{historyEvent.eventName}</h3>
+                <p className={styles.historyMeta}>
+                  {historyEvent.country} · {historyEvent.locality} |{' '}
+                  {formatDate(historyEvent.raceDate)}
+                </p>
+                <div className={styles.historyStats}>
+                  <span className={styles.chip}>
+                    상태: {historyEvent.summary}
+                  </span>
+                  <span className={styles.chip}>
+                    기온 {historyEvent.airTemp}℃ / 노면 {historyEvent.trackTemp}℃
+                  </span>
+                  <span className={styles.chip}>강수 {historyEvent.rainChance}%</span>
+                  <span className={styles.chip}>
+                    풍향 {historyEvent.windDirection} · {historyEvent.windSpeed} km/h
+                  </span>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      </div>
+      <Footer />
+    </MainContainer>
+  );
+};

--- a/src/domain/weather/styles/weatherPage.css.ts
+++ b/src/domain/weather/styles/weatherPage.css.ts
@@ -1,0 +1,461 @@
+import { style } from '@vanilla-extract/css';
+
+export const page = style({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 28,
+  paddingTop: 96,
+  paddingBottom: 120,
+});
+
+export const hero = style({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 1fr) 320px',
+  gap: 28,
+  padding: '32px 36px',
+  borderRadius: 28,
+  background:
+    'linear-gradient(135deg, rgba(26, 44, 92, 0.95), rgba(67, 104, 198, 0.9))',
+  border: '1px solid rgba(96, 126, 230, 0.42)',
+  boxShadow: '0 28px 68px rgba(8, 14, 36, 0.6)',
+  color: '#e6edff',
+  selectors: {
+    ':root.light &': {
+      background:
+        'linear-gradient(135deg, rgba(226, 234, 255, 0.95), rgba(176, 197, 255, 0.9))',
+      border: '1px solid rgba(152, 174, 240, 0.52)',
+      boxShadow: '0 24px 56px rgba(108, 134, 224, 0.26)',
+      color: '#101a38',
+    },
+  },
+  '@media': {
+    'screen and (max-width: 1100px)': {
+      gridTemplateColumns: '1fr',
+    },
+  },
+});
+
+export const heroText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+});
+
+export const heroTitle = style({
+  margin: 0,
+  fontSize: 34,
+  fontWeight: 800,
+  letterSpacing: '-0.02em',
+});
+
+export const heroSubtitle = style({
+  margin: 0,
+  fontSize: 16,
+  lineHeight: 1.6,
+  color: 'rgba(220, 232, 255, 0.86)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(40, 54, 102, 0.75)',
+    },
+  },
+});
+
+export const heroMeta = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+  gap: 12,
+  marginTop: 12,
+});
+
+export const metaCard = style({
+  padding: '12px 14px',
+  borderRadius: 14,
+  background: 'rgba(16, 22, 48, 0.38)',
+  border: '1px solid rgba(116, 146, 234, 0.35)',
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(218, 228, 255, 0.78)',
+      border: '1px solid rgba(160, 180, 240, 0.32)',
+    },
+  },
+});
+
+export const metaLabel = style({
+  display: 'block',
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.16em',
+  color: 'rgba(172, 194, 255, 0.75)',
+  marginBottom: 4,
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(66, 88, 142, 0.72)',
+    },
+  },
+});
+
+export const metaValue = style({
+  fontSize: 20,
+  fontWeight: 700,
+});
+
+export const metaSub = style({
+  display: 'block',
+  marginTop: 2,
+  fontSize: 13,
+  color: 'rgba(214, 226, 255, 0.75)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(54, 70, 120, 0.72)',
+    },
+  },
+});
+
+export const heroCard = style({
+  padding: 20,
+  borderRadius: 18,
+  background: 'rgba(7, 12, 28, 0.45)',
+  border: '1px solid rgba(104, 140, 230, 0.35)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(214, 226, 255, 0.85)',
+      border: '1px solid rgba(150, 174, 240, 0.32)',
+    },
+  },
+});
+
+export const heroBadge = style({
+  alignSelf: 'flex-start',
+  padding: '6px 12px',
+  borderRadius: 999,
+  fontSize: 12,
+  fontWeight: 700,
+  letterSpacing: '0.04em',
+  background: 'rgba(112, 186, 255, 0.18)',
+  border: '1px solid rgba(112, 186, 255, 0.45)',
+  color: '#e6f3ff',
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(40, 82, 160, 0.08)',
+      color: '#14305c',
+      border: '1px solid rgba(36, 94, 186, 0.16)',
+    },
+  },
+});
+
+export const heroHighlight = style({
+  fontSize: 28,
+  fontWeight: 800,
+});
+
+export const heroStatus = style({
+  margin: 0,
+  color: 'rgba(214, 226, 255, 0.78)',
+  fontSize: 14,
+  lineHeight: 1.5,
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(48, 62, 110, 0.82)',
+    },
+  },
+});
+
+export const layout = style({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(320px, 380px) minmax(0, 1fr)',
+  gap: 24,
+  '@media': {
+    'screen and (max-width: 1200px)': {
+      gridTemplateColumns: '1fr',
+    },
+  },
+});
+
+export const sectionCard = style({
+  borderRadius: 16,
+  background: 'rgba(12, 16, 32, 0.7)',
+  border: '1px solid rgba(118, 136, 192, 0.32)',
+  padding: 18,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 14,
+  selectors: {
+    ':root.light &': {
+      background: '#f7f8ff',
+      border: '1px solid rgba(128, 152, 210, 0.25)',
+    },
+  },
+});
+
+export const sectionTitle = style({
+  margin: 0,
+  fontSize: 18,
+  fontWeight: 700,
+});
+
+export const description = style({
+  margin: 0,
+  fontSize: 14,
+  lineHeight: 1.6,
+  color: 'rgba(200, 210, 235, 0.78)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(42, 56, 92, 0.78)',
+    },
+  },
+});
+
+export const eventList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+});
+
+export const eventButton = style({
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '12px 14px',
+  borderRadius: 14,
+  background: 'rgba(20, 28, 48, 0.7)',
+  border: '1px solid rgba(118, 138, 210, 0.28)',
+  color: 'inherit',
+  cursor: 'pointer',
+  transition: 'transform 0.15s ease, border-color 0.15s ease',
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(240, 244, 255, 0.95)',
+      border: '1px solid rgba(144, 166, 220, 0.26)',
+    },
+    '&:hover': {
+      transform: 'translateY(-1px)',
+      borderColor: 'rgba(116, 156, 255, 0.55)',
+    },
+  },
+});
+
+export const activeEvent = style({
+  borderColor: 'rgba(136, 182, 255, 0.8)',
+  background: 'linear-gradient(135deg, rgba(60, 90, 160, 0.4), rgba(90, 126, 210, 0.35))',
+  selectors: {
+    ':root.light &': {
+      background: 'linear-gradient(135deg, rgba(192, 210, 255, 0.55), rgba(224, 234, 255, 0.75))',
+      borderColor: 'rgba(112, 146, 220, 0.8)',
+    },
+  },
+});
+
+export const eventLabel = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+});
+
+export const eventName = style({
+  fontSize: 15,
+  fontWeight: 700,
+});
+
+export const eventMeta = style({
+  fontSize: 13,
+  color: 'rgba(196, 210, 235, 0.7)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(56, 70, 110, 0.7)',
+    },
+  },
+});
+
+export const badge = style({
+  padding: '6px 10px',
+  borderRadius: 999,
+  fontSize: 12,
+  fontWeight: 700,
+  letterSpacing: '0.03em',
+  background: 'rgba(126, 202, 255, 0.18)',
+  color: '#dfefff',
+  border: '1px solid rgba(126, 202, 255, 0.36)',
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(40, 98, 170, 0.08)',
+      color: '#143260',
+      border: '1px solid rgba(64, 120, 198, 0.26)',
+    },
+  },
+});
+
+export const detailCard = style({
+  borderRadius: 18,
+  background: 'rgba(10, 14, 30, 0.75)',
+  border: '1px solid rgba(116, 138, 210, 0.32)',
+  padding: 20,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  selectors: {
+    ':root.light &': {
+      background: '#f6f8ff',
+      border: '1px solid rgba(126, 152, 208, 0.28)',
+    },
+  },
+});
+
+export const statsGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+  gap: 12,
+});
+
+export const stat = style({
+  padding: 12,
+  borderRadius: 12,
+  background: 'rgba(20, 28, 56, 0.7)',
+  border: '1px solid rgba(130, 152, 210, 0.25)',
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(228, 236, 255, 0.8)',
+      border: '1px solid rgba(136, 162, 210, 0.24)',
+    },
+  },
+});
+
+export const statLabel = style({
+  fontSize: 12,
+  color: 'rgba(194, 206, 232, 0.78)',
+  letterSpacing: '0.02em',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(56, 70, 104, 0.78)',
+    },
+  },
+});
+
+export const statValue = style({
+  fontSize: 18,
+  fontWeight: 700,
+  marginTop: 4,
+});
+
+export const sessionList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+});
+
+export const sessionRow = style({
+  display: 'grid',
+  gridTemplateColumns: '120px 1fr',
+  alignItems: 'center',
+  gap: 12,
+  padding: '10px 12px',
+  borderRadius: 12,
+  background: 'rgba(18, 24, 48, 0.64)',
+  border: '1px solid rgba(116, 138, 210, 0.22)',
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(226, 234, 255, 0.84)',
+      border: '1px solid rgba(130, 154, 210, 0.18)',
+    },
+  },
+});
+
+export const sessionTitle = style({
+  fontWeight: 700,
+  fontSize: 14,
+});
+
+export const sessionMeta = style({
+  display: 'flex',
+  gap: 12,
+  flexWrap: 'wrap',
+  fontSize: 13,
+  color: 'rgba(198, 210, 235, 0.78)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(44, 60, 102, 0.78)',
+    },
+  },
+});
+
+export const historyControl = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+});
+
+export const select = style({
+  padding: '10px 12px',
+  borderRadius: 12,
+  border: '1px solid rgba(126, 152, 210, 0.42)',
+  background: 'rgba(14, 18, 32, 0.9)',
+  color: '#e6edff',
+  selectors: {
+    ':root.light &': {
+      background: '#fff',
+      color: '#0f1c40',
+      border: '1px solid rgba(130, 152, 200, 0.36)',
+    },
+  },
+});
+
+export const historyCard = style({
+  borderRadius: 14,
+  padding: 14,
+  background: 'rgba(16, 22, 44, 0.8)',
+  border: '1px solid rgba(126, 152, 210, 0.3)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(238, 242, 255, 0.98)',
+      border: '1px solid rgba(132, 154, 202, 0.24)',
+    },
+  },
+});
+
+export const historyTitle = style({
+  margin: 0,
+  fontSize: 15,
+  fontWeight: 700,
+});
+
+export const historyMeta = style({
+  margin: 0,
+  fontSize: 13,
+  color: 'rgba(196, 210, 236, 0.78)',
+  selectors: {
+    ':root.light &': {
+      color: 'rgba(44, 58, 96, 0.8)',
+    },
+  },
+});
+
+export const historyStats = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+  gap: 8,
+});
+
+export const chip = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '6px 10px',
+  borderRadius: 999,
+  background: 'rgba(138, 176, 255, 0.14)',
+  border: '1px solid rgba(138, 176, 255, 0.32)',
+  fontSize: 13,
+  selectors: {
+    ':root.light &': {
+      background: 'rgba(42, 96, 180, 0.06)',
+      border: '1px solid rgba(42, 96, 180, 0.18)',
+      color: '#102a52',
+    },
+  },
+});

--- a/src/shared/ui/sidebar/SideBar.tsx
+++ b/src/shared/ui/sidebar/SideBar.tsx
@@ -16,6 +16,7 @@ import {
   NewsIcon,
   SunIcon,
   ThemeIcon,
+  WeatherIcon,
 } from '@shared/ui/sidebar/SideBarIcons.tsx';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -26,6 +27,7 @@ interface SideBarProps {
 
 const primaryNavigation: MenuItem[] = [
   { label: '레이스 캘린더', Icon: CalendarIcon, path: '/calendar' },
+  { label: '날씨', Icon: WeatherIcon, path: '/weather', variant: 'highlight' },
   { label: '뉴스', Icon: NewsIcon, path: '/news' },
   { label: '스타팅 그리드', Icon: DocumentIcon, path: '/starting-grid' },
   { label: '크리에이터 콘텐츠', Icon: CreatorIcon, path: '/creator' },

--- a/src/shared/ui/sidebar/SideBarIcons.tsx
+++ b/src/shared/ui/sidebar/SideBarIcons.tsx
@@ -70,6 +70,24 @@ export const NewsIcon = ({ className }: SvgIconProps) => (
   </svg>
 );
 
+export const WeatherIcon = ({ className }: SvgIconProps) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M14.5 7.5a3.5 3.5 0 1 0-6.8 1M8 10a4 4 0 1 0 0 8h8.75A3.25 3.25 0 0 0 20 14.75 3.75 3.75 0 0 0 16.25 11H15"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M13 4.5 13.3 3M8.8 6.5 7.5 5.7M17 6.5l1.1-1.3M7 11.5 6 12.7"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
 export const DocumentIcon = ({ className }: SvgIconProps) => (
   <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
     <path


### PR DESCRIPTION
## Summary
- add mock weather data derived from the calendar schedule to emulate openf1 weather responses
- build a new weather page with upcoming race highlight, per-event session forecasts, and past race dropdown
- add the weather route and sidebar navigation entry for quick access

## Testing
- yarn lint *(fails: missing eslint package in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bacc4871083319a363d0fd238411d)